### PR TITLE
fix: add stalled stream protection config to SSO client (#1929)

### DIFF
--- a/crates/chat-cli/src/auth/builder_id.rs
+++ b/crates/chat-cli/src/auth/builder_id.rs
@@ -49,6 +49,7 @@ use tracing::{
     warn,
 };
 
+use crate::api_client::clients::shared::stalled_stream_protection_config;
 use crate::auth::AuthError;
 use crate::auth::consts::*;
 use crate::auth::scope::is_scopes;
@@ -86,6 +87,7 @@ pub fn client(region: Region) -> Client {
             .region(region)
             .retry_config(RetryConfig::standard().with_max_attempts(3))
             .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+            .stalled_stream_protection(stalled_stream_protection_config())
             .app_name(app_name())
             .build(),
     )

--- a/crates/fig_auth/src/builder_id.rs
+++ b/crates/fig_auth/src/builder_id.rs
@@ -42,6 +42,7 @@ use aws_smithy_runtime_api::client::identity::{
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::region::Region;
 use aws_types::request_id::RequestId;
+use aws_types::sdk_config::StalledStreamProtectionConfig;
 use fig_aws_common::app_name;
 use fig_telemetry_core::{
     Event,
@@ -101,6 +102,11 @@ pub(crate) fn client(region: Region) -> Client {
         .region(region)
         .retry_config(retry_config)
         .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+        .stalled_stream_protection(
+            StalledStreamProtectionConfig::enabled()
+                .grace_period(std::time::Duration::from_secs(60))
+                .build(),
+        )
         .app_name(app_name())
         .build();
     Client::new(&sdk_config)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A mirror of https://github.com/aws/amazon-q-developer-cli/pull/1929 to keep the two repos in sync. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
