### PR TITLE
feat(auth): CreateSubscriptionToken connectors, monthly limit err

### DIFF
--- a/crates/chat-cli/src/api_client/consts.rs
+++ b/crates/chat-cli/src/api_client/consts.rs
@@ -13,3 +13,8 @@ pub const PROD_CODEWHISPERER_FRA_ENDPOINT_REGION: Region = Region::from_static("
 
 // Opt out constants
 pub const X_AMZN_CODEWHISPERER_OPT_OUT_HEADER: &str = "x-amzn-codewhisperer-optout";
+
+// Dummy value that simply provides subscription status (for the holder of a given bearer token)
+// This is a design decision on the service-side to avoid creating a dedicated status API.
+#[allow(dead_code)] // TODO: Remove
+pub const SUBSCRIPTION_STATUS_ACCOUNT_ID: &str = "111111111111";

--- a/crates/chat-cli/src/api_client/error.rs
+++ b/crates/chat-cli/src/api_client/error.rs
@@ -1,3 +1,4 @@
+use amzn_codewhisperer_client::operation::create_subscription_token::CreateSubscriptionTokenError;
 use amzn_codewhisperer_client::operation::generate_completions::GenerateCompletionsError;
 use amzn_codewhisperer_client::operation::list_available_customizations::ListAvailableCustomizationsError;
 use amzn_codewhisperer_client::operation::list_available_profiles::ListAvailableProfilesError;
@@ -48,6 +49,13 @@ pub enum ApiClientError {
     // quota breach
     #[error("quota has reached its limit")]
     QuotaBreach(&'static str),
+
+    // Separate from quota breach (somehow)
+    #[error("monthly query limit reached")]
+    MonthlyLimitReached,
+
+    #[error("{}", SdkErrorDisplay(.0))]
+    CreateSubscriptionToken(#[from] SdkError<CreateSubscriptionTokenError, HttpResponse>),
 
     /// Returned from the backend when the user input is too large to fit within the model context
     /// window.
@@ -110,6 +118,10 @@ mod tests {
             )),
             ApiClientError::QDeveloperSendMessage(SdkError::service_error(
                 QDeveloperSendMessageError::unhandled("<unhandled>"),
+                response(),
+            )),
+            ApiClientError::CreateSubscriptionToken(SdkError::service_error(
+                CreateSubscriptionTokenError::unhandled("<unhandled>"),
                 response(),
             )),
             ApiClientError::CodewhispererChatResponseStream(SdkError::service_error(


### PR DESCRIPTION
- Adds client interface for using CreateSubscriptionToken to get a url to upgrade a builder ID from free to paid tier.
- Adds code to detect monthly usage limit exceptions, which are not the same as quota breaches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
