### PR TITLE
feat(windows): refactor filesystem handling to support windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
+ "typed-path",
  "unicode-width 0.2.0",
  "url",
  "uuid",
@@ -9321,6 +9322,12 @@ dependencies = [
  "thiserror 2.0.12",
  "utf-8",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c462d18470a2857aa657d338af5fa67170bb48bcc80a296710ce3b0802a32566"
 
 [[package]]
 name = "typeid"

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -149,6 +149,7 @@ tracing-subscriber = { version = "0.3.19", features = [
     "parking_lot",
     "time",
 ] }
+typed-path = "0.11.0"
 unicode-width = "0.2.0"
 url = "2.5.4"
 uuid = { version = "1.15.1", features = ["v4", "serde"] }

--- a/crates/chat-cli/src/cli/chat/mcp.rs
+++ b/crates/chat-cli/src/cli/chat/mcp.rs
@@ -256,7 +256,7 @@ fn resolve_scope_profile(ctx: &Context, scope: Option<Scope>) -> Result<PathBuf>
 
 fn expand_path(ctx: &Context, p: &str) -> Result<PathBuf> {
     let p = shellexpand::tilde(p);
-    let mut path = PathBuf::from(p.as_ref());
+    let mut path = PathBuf::from(p.as_ref() as &str);
     if path.is_relative() {
         path = ctx.env().current_dir()?.join(path);
     }

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -180,7 +180,7 @@ impl McpServerConfig {
         let mut cwd = std::env::current_dir()?;
         cwd.push(".amazonq/mcp.json");
         let expanded_path = shellexpand::tilde("~/.aws/amazonq/mcp.json");
-        let global_path = PathBuf::from(expanded_path.as_ref());
+        let global_path = PathBuf::from(expanded_path.as_ref() as &str);
         let global_buf = tokio::fs::read(global_path).await.ok();
         let local_buf = tokio::fs::read(cwd).await.ok();
         let conf = match (global_buf, local_buf) {

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -497,6 +497,7 @@ fn format_ftype(md: &Metadata) -> char {
 }
 
 /// Formats a permissions mode into the form used by `ls`, e.g. `0o644` to `rw-r--r--`
+#[cfg(unix)]
 fn format_mode(mode: u32) -> [char; 9] {
     let mut mode = mode & 0o777;
     let mut res = ['-'; 9];
@@ -644,6 +645,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_format_mode() {
         macro_rules! assert_mode {
             ($actual:expr, $expected:expr) => {

--- a/crates/chat-cli/src/platform/fs/mod.rs
+++ b/crates/chat-cli/src/platform/fs/mod.rs
@@ -67,13 +67,13 @@ fn append(base: impl AsRef<Path>, path: impl AsRef<Path>) -> PathBuf {
     #[cfg(test)]
     {
         // Normalize the path for tests, then use the platform-specific append
-        return platform_append(normalize_test_path(base), normalize_test_path(path));
+        platform_append(normalize_test_path(base), normalize_test_path(path))
     }
 
     #[cfg(not(test))]
     {
         // In non-test code, just use the platform-specific append directly
-        return platform_append(base, path);
+        platform_append(base, path)
     }
 }
 

--- a/crates/chat-cli/src/platform/fs/mod.rs
+++ b/crates/chat-cli/src/platform/fs/mod.rs
@@ -13,6 +13,64 @@ use std::sync::{
 use tempfile::TempDir;
 use tokio::fs;
 
+// Import platform-specific modules
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+// Use platform-specific functions
+#[cfg(unix)]
+use unix::{
+    append as platform_append,
+    symlink_sync,
+};
+#[cfg(windows)]
+use windows::{
+    append as platform_append,
+    symlink_sync,
+};
+
+/// Rust path handling is hard coded to work specific ways depending on the 
+/// OS that is being executed on. Because of this, if Unix paths are provided, 
+/// they aren't recognized. For example a leading prefix of '/' isn't considered
+/// an absolute path. To fix this, all test paths would need to have windows 
+/// equivalents which is tedious and can lead to errors. To make writing tests 
+/// easier, path normalization happens on Windows systems implicitly during test
+/// runtime. 
+#[cfg(test)]
+fn normalize_test_path(path: impl AsRef<Path>) -> PathBuf {
+    #[cfg(windows)]
+    {
+        use typed_path::{Utf8TypedPath};
+        let path_ref = path.as_ref();
+        
+        // Only process string paths with forward slashes
+        let typed_path = Utf8TypedPath::derive(path_ref.to_str().unwrap());
+        if typed_path.is_unix() {
+            return PathBuf::from(typed_path.with_windows_encoding().to_string());
+        }
+
+    }
+    path.as_ref().to_path_buf()
+}
+
+/// Cross-platform path append that handles test paths consistently
+fn append(base: impl AsRef<Path>, path: impl AsRef<Path>) -> PathBuf {
+    #[cfg(test)]
+    {
+        // Normalize the path for tests, then use the platform-specific append
+        let normalized_path = normalize_test_path(path);
+        return platform_append(base, normalized_path);
+    }
+    
+    #[cfg(not(test))]
+    {
+        // In non-test code, just use the platform-specific append directly
+        return platform_append(base, path);
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Fs(inner::Inner);
 
@@ -285,14 +343,22 @@ impl Fs {
     /// Creates a new symbolic link on the filesystem.
     ///
     /// The `link` path will be a symbolic link pointing to the `original` path.
-    ///
-    /// This is a proxy to [`tokio::fs::symlink`].
-    #[cfg(unix)]
     pub async fn symlink(&self, original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
         use inner::Inner;
+
+        #[cfg(unix)]
+        async fn do_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+            fs::symlink(original, link).await
+        }
+
+        #[cfg(windows)]
+        async fn do_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+            windows::symlink_async(original, link).await
+        }
+
         match &self.0 {
-            Inner::Real => fs::symlink(original, link).await,
-            Inner::Chroot(root) => fs::symlink(append(root.path(), original), append(root.path(), link)).await,
+            Inner::Real => do_symlink(original, link).await,
+            Inner::Chroot(root) => do_symlink(append(root.path(), original), append(root.path(), link)).await,
             Inner::Fake(_) => panic!("unimplemented"),
         }
     }
@@ -300,14 +366,11 @@ impl Fs {
     /// Creates a new symbolic link on the filesystem.
     ///
     /// The `link` path will be a symbolic link pointing to the `original` path.
-    ///
-    /// This is a proxy to [`std::os::unix::fs::symlink`].
-    #[cfg(unix)]
     pub fn symlink_sync(&self, original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
         use inner::Inner;
         match &self.0 {
-            Inner::Real => std::os::unix::fs::symlink(original, link),
-            Inner::Chroot(root) => std::os::unix::fs::symlink(append(root.path(), original), append(root.path(), link)),
+            Inner::Real => symlink_sync(original, link),
+            Inner::Chroot(root) => symlink_sync(append(root.path(), original), append(root.path(), link)),
             Inner::Fake(_) => panic!("unimplemented"),
         }
     }
@@ -401,35 +464,6 @@ impl Fs {
             _ => path.as_ref().to_path_buf().to_string_lossy().to_string(),
         }
     }
-}
-
-/// Performs `a.join(b)`, except:
-/// - if `b` is an absolute path, then the resulting path will equal `/a/b`
-/// - if the prefix of `b` contains some `n` copies of a, then the resulting path will equal `/a/b`
-#[cfg(unix)]
-fn append(a: impl AsRef<Path>, b: impl AsRef<Path>) -> PathBuf {
-    use std::ffi::OsString;
-    use std::os::unix::ffi::{
-        OsStrExt,
-        OsStringExt,
-    };
-
-    // Have to use byte slices since rust seems to always append
-    // a forward slash at the end of a path...
-    let a = a.as_ref().as_os_str().as_bytes();
-    let mut b = b.as_ref().as_os_str().as_bytes();
-    while b.starts_with(a) {
-        b = b.strip_prefix(a).unwrap();
-    }
-    while b.starts_with(b"/") {
-        b = b.strip_prefix(b"/").unwrap();
-    }
-    PathBuf::from(OsString::from_vec(a.to_vec())).join(PathBuf::from(OsString::from_vec(b.to_vec())))
-}
-
-#[cfg(windows)]
-fn append(a: impl AsRef<Path>, b: impl AsRef<Path>) -> PathBuf {
-    todo!()
 }
 
 #[cfg(test)]

--- a/crates/chat-cli/src/platform/fs/unix.rs
+++ b/crates/chat-cli/src/platform/fs/unix.rs
@@ -1,0 +1,51 @@
+use std::ffi::OsString;
+use std::os::unix::ffi::{
+    OsStrExt,
+    OsStringExt,
+};
+use std::path::{
+    Path,
+    PathBuf,
+};
+
+/// Performs `a.join(b)`, except:
+/// - if `b` is an absolute path, then the resulting path will equal `/a/b`
+/// - if the prefix of `b` contains some `n` copies of a, then the resulting path will equal `/a/b`
+pub(super) fn append(a: impl AsRef<Path>, b: impl AsRef<Path>) -> PathBuf {
+    // Have to use byte slices since rust seems to always append
+    // a forward slash at the end of a path...
+    let a = a.as_ref().as_os_str().as_bytes();
+    let mut b = b.as_ref().as_os_str().as_bytes();
+    while b.starts_with(a) {
+        b = b.strip_prefix(a).unwrap();
+    }
+    while b.starts_with(b"/") {
+        b = b.strip_prefix(b"/").unwrap();
+    }
+    PathBuf::from(OsString::from_vec(a.to_vec())).join(PathBuf::from(OsString::from_vec(b.to_vec())))
+}
+
+/// Creates a new symbolic link on the filesystem.
+///
+/// The `link` path will be a symbolic link pointing to the `original` path.
+pub(super) fn symlink_sync(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(original, link)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_append() {
+        macro_rules! assert_append {
+            ($a:expr, $b:expr, $expected:expr) => {
+                assert_eq!(append($a, $b), PathBuf::from($expected));
+            };
+        }
+        assert_append!("/abc/test", "/test", "/abc/test/test");
+        assert_append!("/tmp/.dir", "/tmp/.dir/home/myuser", "/tmp/.dir/home/myuser");
+        assert_append!("/tmp/.dir", "/tmp/hello", "/tmp/.dir/tmp/hello");
+        assert_append!("/tmp/.dir", "/tmp/.dir/tmp/.dir/home/user", "/tmp/.dir/home/user");
+    }
+}

--- a/crates/chat-cli/src/platform/fs/windows.rs
+++ b/crates/chat-cli/src/platform/fs/windows.rs
@@ -1,0 +1,148 @@
+use std::fs::metadata;
+use std::io;
+use std::path::{
+    Component,
+    Path,
+    PathBuf,
+};
+
+use tracing::warn;
+
+/// Performs `a.join(b)`, except:
+/// - if `b` is an absolute path, then the resulting path will equal `/a/b`
+/// - if the prefix of `b` contains some `n` copies of a, then the resulting path will equal `/a/b`
+pub(super) fn append(a: impl AsRef<Path>, b: impl AsRef<Path>) -> PathBuf {
+    let a = a.as_ref();
+    let b = b.as_ref();
+
+    // If b is an absolute path with a Windows drive letter, handle it specially
+    if b.is_absolute() {
+        // First, try to strip any common prefix
+        if let Ok(stripped) = b.strip_prefix(a) {
+            return a.join(stripped);
+        }
+        
+        // If that fails, we need to handle Windows drive letter paths
+        // Get the non-prefix part of the path (everything after C:\)
+        let mut components = b.components();
+        
+        // Skip the prefix (drive letter) and root (\ after C:)
+        // and create a new path from the remaining components
+        if let Some(Component::Prefix(_)) = components.next() {
+            if let Some(Component::RootDir) = components.next() {
+                let remainder: PathBuf = components.collect();
+                return a.join(remainder);
+            }
+        }
+        
+        // Fallback: if we can't recognize the structure, just remove the drive letter
+        let drive_letter_removed = b.to_string_lossy()
+            .trim_start_matches(|c: char| c.is_ascii_alphabetic() || c == ':' || c == '\\')
+            .to_string();
+            
+        return a.join(drive_letter_removed);
+    }
+    
+    // Check if b starts with a using strip_prefix
+    if let Ok(remaining) = b.strip_prefix(a) {
+        return a.join(remaining);
+    }
+    
+    // Handle the case where string representation matches but Path doesn't
+    // (can happen with case differences or different path separators)
+    let a_str = a.to_string_lossy();
+    let b_str = b.to_string_lossy();
+    
+    // Convert Cow to &str before using starts_with
+    if b_str.starts_with(a_str.as_ref()) {
+        // Remove the prefix that matches a
+        let remaining = &b_str[a_str.len()..];
+        let remaining = remaining.trim_start_matches('\\');
+        return a.join(remaining);
+    }
+
+    // Standard join for other cases
+    a.join(b)
+}
+
+/// Creates a new symbolic link on the filesystem.
+///
+/// The `link` path will be a symbolic link pointing to the `original` path.
+/// On Windows, we need to determine if the target is a file or directory.
+pub(super) fn symlink_sync(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    // Determine if the original is a file or directory
+    let meta = metadata(original.as_ref())?;
+    if meta.is_dir() {
+        std::os::windows::fs::symlink_dir(original, link)
+    } else {
+        std::os::windows::fs::symlink_file(original, link)
+    }
+}
+
+/// Creates a new symbolic link asynchronously.
+///
+/// This is a helper function for the Windows implementation.
+pub(super) async fn symlink_async(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    // Determine if the original is a file or directory
+    let meta = metadata(original.as_ref())?;
+    if meta.is_dir() {
+        tokio::fs::symlink_dir(original, link).await
+    } else {
+        tokio::fs::symlink_file(original, link).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_append() {
+        macro_rules! assert_append {
+            ($a:expr, $b:expr, $expected:expr) => {
+                assert_eq!(append($a, $b), PathBuf::from($expected));
+            };
+        }
+
+        // Test different drive letters (should strip prefix)
+        assert_append!("C:\\temp", "D:\\test", "C:\\temp\\test");
+        
+        // Test same path prefixes (should use strip_prefix)
+        assert_append!("C:\\temp", "C:\\temp\\subdir", "C:\\temp\\subdir");
+        assert_append!("C:\\temp", "C:\\temp\\subdir\\file.txt", "C:\\temp\\subdir\\file.txt");
+        
+        // Test relative path (standard join)
+        assert_append!("C:\\temp", "subdir\\file.txt", "C:\\temp\\subdir\\file.txt");
+        
+        // Test different absolute paths with same drive (strip drive and root)
+        assert_append!("C:\\temprootdir", "C:\\test_file.txt", "C:\\temprootdir\\test_file.txt");
+        
+        // Test different absolute paths with different drives
+        assert_append!("C:\\temprootdir", "D:\\test_file.txt", "C:\\temprootdir\\test_file.txt");
+        
+        // Test paths with mixed case (should be case-insensitive on Windows)
+        assert_append!("C:\\Temp", "c:\\temp\\file.txt", "C:\\Temp\\file.txt");
+    }
+}
+
+#[cfg(test)]
+#[cfg(windows)]
+mod integration_tests {
+    use super::*;
+    use tempfile::TempDir;
+    
+    #[test]
+    fn test_append_with_real_paths() {
+        // Create a temporary directory for testing
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+        
+        // Test appending an absolute path
+        let drive_letter = temp_path.to_string_lossy().chars().next().unwrap_or('C');
+        let absolute_path = format!("{}:\\test.txt", drive_letter);
+        
+        let result = append(temp_path, absolute_path);
+        assert!(result.to_string_lossy().contains("test.txt"));
+        assert!(!result.to_string_lossy().contains(":\\test.txt"));
+    }
+}

--- a/crates/chat-cli/src/platform/fs/windows.rs
+++ b/crates/chat-cli/src/platform/fs/windows.rs
@@ -122,7 +122,6 @@ mod tests {
 }
 
 #[cfg(test)]
-#[cfg(windows)]
 mod integration_tests {
     use tempfile::TempDir;
 


### PR DESCRIPTION
# Add Windows-specific path handling and code cleanup

This PR introduces Windows-specific path handling functionality and includes code cleanup to address Clippy
warnings.

## Changes

• **Windows Path Handling**: Added Windows-specific path appending functionality to ensure proper path
construction on Windows systems
  • Implemented automatic path normalization for Windows during test runtime
  • Addresses the challenge where Unix-style paths aren't properly recognized on Windows systems
  • Eliminates the need to maintain separate test paths for different operating systems

• **Code Cleanup**: Fixed Clippy warnings to improve code quality and maintainability

## Implementation Notes

Rust's path handling is OS-dependent, creating challenges for cross-platform testing. On Windows, Unix-style
paths (with forward slashes) aren't properly recognized - for example, a leading / isn't interpreted as an
absolute path. Rather than creating separate Windows and Unix test paths (which would be tedious and error-
prone), this implementation automatically normalizes paths on Windows systems during test runtime, allowing
developers to write tests with a single, consistent set of paths.

## Testing

• Verified Windows path handling works correctly with both forward and backslashes
• Ensured all Clippy warnings are resolved
• Confirmed existing functionality remains intact