### PR TITLE
adds parent process envs to aws cli tool command

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -51,6 +51,7 @@ impl UseAws {
 
     pub async fn invoke(&self, _ctx: &Context, _updates: impl Write) -> Result<InvokeOutput> {
         let mut command = tokio::process::Command::new("aws");
+        command.envs(std::env::vars());
 
         // Set up environment variables
         let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();


### PR DESCRIPTION
*Issue #, if available:*
Some users have reported that aws cli sometimes fail to run certain commands that they are able to run manually. 
These errors look like the following:
```
Traceback (most recent call last):
  File "/opt/homebrew/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/opt/homebrew/lib/python3.11/site-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/client.py", line 15, in <module>
    from botocore import waiter, xform_name
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/waiter.py", line 20, in <module>
    from botocore.docs.docstring import WaiterDocstring
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/docs/__init__.py", line 15, in <module>
    from botocore.docs.service import ServiceDocumenter
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/docs/service.py", line 13, in <module>
    from botocore.docs.bcdoc.restdoc import DocumentStructure
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/docs/bcdoc/restdoc.py", line 17, in <module>
    from botocore.compat import OrderedDict
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/compat.py", line 32, in <module>
    from urllib3 import exceptions
ImportError: cannot import name 'exceptions' from 'urllib3' (unknown location)
```

*Description of changes:*
Add parent process envs to child process spawned. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
