### PR TITLE
Fix: mcp start command not respecting tilde

### DIFF
--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -162,7 +162,8 @@ impl Client<StdioTransport> {
             env,
         } = config;
         let child = {
-            let mut command = tokio::process::Command::new(bin_path);
+            let expanded_bin_path = shellexpand::tilde(&bin_path);
+            let mut command = tokio::process::Command::new(expanded_bin_path.as_ref());
             command
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/1857

*Description of changes:*
Adds tilde expansion to mcp start command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
