### PR TITLE
Fix: sigint not caught during parsing of large block of text

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3385,7 +3385,7 @@ impl ChatContext {
 
                 // TODO: We should buffer output based on how much we have to parse, not as a constant
                 // Do not remove unless you are nabochay :)
-                std::thread::sleep(Duration::from_millis(8));
+                tokio::time::sleep(Duration::from_millis(8)).await;
             }
 
             // Set spinner after showing all of the assistant text content so far.


### PR DESCRIPTION
*Issue #, if available:*
Users report:
When Q is streaming a large block of text, ctrl-c no longer interrupts the output.

*Description of changes:*
There exists a `handle_response` function, which is polled along side the sigint handler:
```rust
ChatState::HandleResponseStream(response) => tokio::select! {
    res = self.handle_response(database, telemetry, response) => res,
    Ok(_) = ctrl_c_stream => Err(ChatError::Interrupted { tool_uses: None })
},
```

But `handle_response` never yields when it processes a large block content when it processes a large block of text, due to the following loop:
```rust
            loop {
                let input = Partial::new(&buf[offset..]);
                match interpret_markdown(input, &mut self.output, &mut state) {
                    Ok(parsed) => {
                        offset += parsed.offset_from(&input);
                        self.output.flush()?;
                        state.newline = state.set_newline;
                        state.set_newline = false;
                    },
                    Err(err) => match err.into_inner() {
                        Some(err) => return Err(ChatError::Custom(err.to_string().into())),
                        None => break, // Data was incomplete
                    },
                }

                // TODO: We should buffer output based on how much we have to parse, not as a constant
                // Do not remove unless you are nabochay :)
                std::time::sleep(Duration::from_millis(8)).await;
            }
```
Note that the entire loop is synchronous, and it won't yield if it just keeps running. 

Tokio select has the following description:
> The macro aggregates all `<async expression>` expressions and runs them
concurrently on the **current** task. 

As a result, ctrl_c_stream never gets polled. 

By changing the sleep to an async aware version, this enables the runtime to poll the other arm in the select. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
