### PR TITLE
feat(telemetry): stable reason codes, reasonDesc field

### DIFF
--- a/crates/chat-cli/src/cli/chat/parser.rs
+++ b/crates/chat-cli/src/cli/chat/parser.rs
@@ -21,6 +21,7 @@ use super::message::{
 };
 use crate::api_client::clients::SendMessageOutput;
 use crate::api_client::model::ChatResponseStream;
+use crate::telemetry::ReasonCode;
 
 #[derive(Debug, Error)]
 pub struct RecvError {
@@ -28,6 +29,12 @@ pub struct RecvError {
     pub request_id: Option<String>,
     #[source]
     pub source: RecvErrorKind,
+}
+
+impl ReasonCode for RecvError {
+    fn reason_code(&self) -> String {
+        "RecvError".to_string()
+    }
 }
 
 impl std::fmt::Display for RecvError {

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -130,6 +130,7 @@ impl Event {
                 request_id,
                 result,
                 reason,
+                reason_desc,
                 ..
             } => Some(
                 CodewhispererterminalAddChatMessage {
@@ -144,6 +145,7 @@ impl Event {
                     codewhispererterminal_context_file_length: context_file_length.map(|l| l as i64).map(Into::into),
                     result: result.to_string().into(),
                     reason: reason.map(Into::into),
+                    reason_desc: reason_desc.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -242,6 +244,7 @@ impl Event {
                 context_file_length,
                 result,
                 reason,
+                reason_desc,
             } => Some(
                 AmazonqMessageResponseError {
                     create_time: self.created_time,
@@ -252,6 +255,7 @@ impl Event {
                     sso_region: self.sso_region.map(Into::into),
                     result: Some(result.to_string().into()),
                     reason: reason.map(Into::into),
+                    reason_desc: reason_desc.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -286,6 +290,7 @@ pub enum EventType {
         context_file_length: Option<usize>,
         result: TelemetryResult,
         reason: Option<String>,
+        reason_desc: Option<String>,
     },
     ToolUseSuggested {
         conversation_id: String,
@@ -322,6 +327,7 @@ pub enum EventType {
     MessageResponseError {
         result: TelemetryResult,
         reason: Option<String>,
+        reason_desc: Option<String>,
         conversation_id: String,
         context_file_length: Option<usize>,
     },

--- a/crates/chat-cli/src/telemetry/definitions.rs
+++ b/crates/chat-cli/src/telemetry/definitions.rs
@@ -29,6 +29,7 @@ mod tests {
             codewhispererterminal_utterance_id: Some("message_id".to_owned().into()),
             result: crate::telemetry::definitions::types::Result::new("Succeeded".to_string()),
             reason: None,
+            reason_desc: None,
         });
 
         let s = serde_json::to_string_pretty(&metric_datum_init).unwrap();

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -63,7 +63,12 @@
     {
       "name": "reason",
       "type": "string",
-      "description": "Description of what caused an error, if any"
+      "description": "Description of what caused an error, if any. Should be a stable/predictable name."
+    },
+    {
+      "name": "reasonDesc",
+      "type": "string",
+      "description": "Error message detail. May contain arbitrary message details (unlike the `reason` field)."
     },
     {
       "name": "codewhispererterminal_toolUseId",
@@ -158,7 +163,8 @@
         { "type": "codewhispererterminal_contextFileLength", "required": false },
         { "type": "requestId" },
         { "type": "result", "required": true },
-        { "type": "reason", "required": false }
+        { "type": "reason", "required": false },
+        { "type": "reasonDesc", "required": false }
       ]
     },
     {
@@ -276,7 +282,8 @@
           { "type": "amazonqConversationId" },
           { "type": "codewhispererterminal_contextFileLength", "required": false },
           { "type": "result" },
-          { "type": "reason", "required": false }
+          { "type": "reason", "required": false },
+          { "type": "reasonDesc", "required": false }
       ]
     }
   ]


### PR DESCRIPTION
- Ports "reasonDesc" from IDE telemetry.
- Add stable reason codes for easier metric tracking

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
