### PR TITLE
feat: q builder id pro subscription flow

### DIFF
--- a/crates/chat-cli/src/api_client/clients/client.rs
+++ b/crates/chat-cli/src/api_client/clients/client.rs
@@ -9,7 +9,6 @@ use amzn_codewhisperer_client::types::{
 use tracing::error;
 
 use super::shared::bearer_sdk_config;
-use crate::api_client::consts::SUBSCRIPTION_STATUS_ACCOUNT_ID;
 use crate::api_client::interceptor::opt_out::OptOutInterceptor;
 use crate::api_client::{
     ApiClientError,
@@ -127,33 +126,18 @@ impl Client {
         }
     }
 
-    #[allow(dead_code)] // TODO: Remove
-    pub async fn create_subscription_token(
-        &self,
-        account_id: &str,
-    ) -> Result<CreateSubscriptionTokenOutput, ApiClientError> {
+    pub async fn create_subscription_token(&self) -> Result<CreateSubscriptionTokenOutput, ApiClientError> {
         match &self.inner {
             inner::Inner::Codewhisperer(client) => client
                 .create_subscription_token()
-                .account_id(account_id)
                 .send()
                 .await
                 .map_err(ApiClientError::CreateSubscriptionToken),
             inner::Inner::Mock => Ok(CreateSubscriptionTokenOutput::builder()
                 .set_encoded_verification_url(Some("test/url".to_string()))
+                .set_status(Some(SubscriptionStatus::Inactive))
+                .set_token(Some("test-token".to_string()))
                 .build()?),
-        }
-    }
-
-    #[allow(dead_code)] // TODO: Remove
-    pub async fn get_subscription_status(&self) -> Result<SubscriptionStatus, ApiClientError> {
-        match &self.inner {
-            inner::Inner::Codewhisperer(_) => Ok(self
-                .create_subscription_token(SUBSCRIPTION_STATUS_ACCOUNT_ID)
-                .await?
-                .status()
-                .clone()),
-            inner::Inner::Mock => Ok(SubscriptionStatus::Active),
         }
     }
 }

--- a/crates/chat-cli/src/api_client/clients/client.rs
+++ b/crates/chat-cli/src/api_client/clients/client.rs
@@ -1,12 +1,15 @@
 use amzn_codewhisperer_client::Client as CodewhispererClient;
+use amzn_codewhisperer_client::operation::create_subscription_token::CreateSubscriptionTokenOutput;
 use amzn_codewhisperer_client::types::{
     OptOutPreference,
+    SubscriptionStatus,
     TelemetryEvent,
     UserContext,
 };
 use tracing::error;
 
 use super::shared::bearer_sdk_config;
+use crate::api_client::consts::SUBSCRIPTION_STATUS_ACCOUNT_ID;
 use crate::api_client::interceptor::opt_out::OptOutInterceptor;
 use crate::api_client::{
     ApiClientError,
@@ -121,6 +124,36 @@ impl Client {
                     profile_name: "MyOtherProfile".to_owned(),
                 },
             ]),
+        }
+    }
+
+    #[allow(dead_code)] // TODO: Remove
+    pub async fn create_subscription_token(
+        &self,
+        account_id: &str,
+    ) -> Result<CreateSubscriptionTokenOutput, ApiClientError> {
+        match &self.inner {
+            inner::Inner::Codewhisperer(client) => client
+                .create_subscription_token()
+                .account_id(account_id)
+                .send()
+                .await
+                .map_err(ApiClientError::CreateSubscriptionToken),
+            inner::Inner::Mock => Ok(CreateSubscriptionTokenOutput::builder()
+                .set_encoded_verification_url(Some("test/url".to_string()))
+                .build()?),
+        }
+    }
+
+    #[allow(dead_code)] // TODO: Remove
+    pub async fn get_subscription_status(&self) -> Result<SubscriptionStatus, ApiClientError> {
+        match &self.inner {
+            inner::Inner::Codewhisperer(_) => Ok(self
+                .create_subscription_token(SUBSCRIPTION_STATUS_ACCOUNT_ID)
+                .await?
+                .status()
+                .clone()),
+            inner::Inner::Mock => Ok(SubscriptionStatus::Active),
         }
     }
 }

--- a/crates/chat-cli/src/api_client/consts.rs
+++ b/crates/chat-cli/src/api_client/consts.rs
@@ -10,8 +10,3 @@ pub const PROD_CODEWHISPERER_FRA_ENDPOINT_REGION: Region = Region::from_static("
 
 // Opt out constants
 pub const X_AMZN_CODEWHISPERER_OPT_OUT_HEADER: &str = "x-amzn-codewhisperer-optout";
-
-// Dummy value that simply provides subscription status (for the holder of a given bearer token)
-// This is a design decision on the service-side to avoid creating a dedicated status API.
-#[allow(dead_code)] // TODO: Remove
-pub const SUBSCRIPTION_STATUS_ACCOUNT_ID: &str = "111111111111";

--- a/crates/chat-cli/src/api_client/consts.rs
+++ b/crates/chat-cli/src/api_client/consts.rs
@@ -10,3 +10,8 @@ pub const PROD_CODEWHISPERER_FRA_ENDPOINT_REGION: Region = Region::from_static("
 
 // Opt out constants
 pub const X_AMZN_CODEWHISPERER_OPT_OUT_HEADER: &str = "x-amzn-codewhisperer-optout";
+
+// Dummy value that simply provides subscription status (for the holder of a given bearer token)
+// This is a design decision on the service-side to avoid creating a dedicated status API.
+#[allow(dead_code)] // TODO: Remove
+pub const SUBSCRIPTION_STATUS_ACCOUNT_ID: &str = "111111111111";

--- a/crates/chat-cli/src/api_client/error.rs
+++ b/crates/chat-cli/src/api_client/error.rs
@@ -96,11 +96,13 @@ impl ReasonCode for ApiClientError {
             ApiClientError::QDeveloperChatResponseStream(e) => sdk_error_code(e),
             ApiClientError::ListAvailableProfilesError(e) => sdk_error_code(e),
             ApiClientError::SendTelemetryEvent(e) => sdk_error_code(e),
+            ApiClientError::CreateSubscriptionToken(e) => sdk_error_code(e),
             ApiClientError::QuotaBreach(_) => "QuotaBreachError".to_string(),
             ApiClientError::ContextWindowOverflow => "ContextWindowOverflow".to_string(),
             ApiClientError::SmithyBuild(_) => "SmithyBuildError".to_string(),
             ApiClientError::AuthError(_) => "AuthError".to_string(),
             ApiClientError::ModelOverloadedError { .. } => "ModelOverloadedError".to_string(),
+            ApiClientError::MonthlyLimitReached => "MonthlyLimitReached".to_string(),
         }
     }
 }

--- a/crates/chat-cli/src/api_client/error.rs
+++ b/crates/chat-cli/src/api_client/error.rs
@@ -1,3 +1,4 @@
+use amzn_codewhisperer_client::operation::create_subscription_token::CreateSubscriptionTokenError;
 use amzn_codewhisperer_client::operation::generate_completions::GenerateCompletionsError;
 use amzn_codewhisperer_client::operation::list_available_customizations::ListAvailableCustomizationsError;
 use amzn_codewhisperer_client::operation::list_available_profiles::ListAvailableProfilesError;
@@ -51,6 +52,13 @@ pub enum ApiClientError {
     // quota breach
     #[error("quota has reached its limit")]
     QuotaBreach(&'static str),
+
+    // Separate from quota breach (somehow)
+    #[error("monthly query limit reached")]
+    MonthlyLimitReached,
+
+    #[error("{}", SdkErrorDisplay(.0))]
+    CreateSubscriptionToken(#[from] SdkError<CreateSubscriptionTokenError, HttpResponse>),
 
     /// Returned from the backend when the user input is too large to fit within the model context
     /// window.
@@ -148,6 +156,10 @@ mod tests {
             )),
             ApiClientError::QDeveloperSendMessage(SdkError::service_error(
                 QDeveloperSendMessageError::unhandled("<unhandled>"),
+                response(),
+            )),
+            ApiClientError::CreateSubscriptionToken(SdkError::service_error(
+                CreateSubscriptionTokenError::unhandled("<unhandled>"),
                 response(),
             )),
             ApiClientError::CodewhispererChatResponseStream(SdkError::service_error(

--- a/crates/chat-cli/src/auth/builder_id.rs
+++ b/crates/chat-cli/src/auth/builder_id.rs
@@ -41,6 +41,10 @@ use aws_smithy_runtime_api::client::identity::{
 };
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::region::Region;
+use eyre::{
+    Result,
+    eyre,
+};
 use time::OffsetDateTime;
 use tracing::{
     debug,
@@ -565,6 +569,17 @@ impl ResolveIdentity for BearerResolver {
                 None => Err(AuthError::NoToken.into()),
             }
         }))
+    }
+}
+
+pub async fn is_idc_user(database: &Database) -> Result<bool> {
+    if cfg!(test) {
+        return Ok(false);
+    }
+    if let Ok(Some(token)) = BuilderIdToken::load(database).await {
+        Ok(token.token_type() == TokenType::IamIdentityCenter)
+    } else {
+        Err(eyre!("No auth token found - is the user signed in?"))
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/command.rs
+++ b/crates/chat-cli/src/cli/chat/command.rs
@@ -60,6 +60,9 @@ pub enum Command {
     },
     Mcp,
     Model,
+    Subscribe {
+        manage: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -841,6 +844,10 @@ impl Command {
                 },
                 "mcp" => Self::Mcp,
                 "model" => Self::Model,
+                "subscribe" => {
+                    let manage = parts.contains(&"--manage");
+                    Self::Subscribe { manage }
+                },
                 unknown_command => {
                     let looks_like_path = {
                         let after_slash_command_str = parts[1..].join(" ");

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -80,6 +80,7 @@ pub const COMMANDS: &[&str] = &[
     "/usage",
     "/save",
     "/load",
+    "/subscribe",
 ];
 
 /// Complete commands that start with a slash

--- a/crates/q_cli/src/cli/user.rs
+++ b/crates/q_cli/src/cli/user.rs
@@ -203,7 +203,7 @@ impl RootUserSubcommand {
 
                 if let Ok(Some(token)) = fig_auth::builder_id_token().await {
                     if matches!(token.token_type(), TokenType::BuilderId) {
-                        bail!("This command is only available for Pro users");
+                        bail!("This command is only available for IAM Identity Center users");
                     }
                 }
 


### PR DESCRIPTION
- Add better message to indicate when the user has reached their monthly query limit.
- Add new command `/subscribe` to initiate a subscription flow to paid usage for builder ID users
  - Includes option `--manage` to open the subscription page on console where to user can cancel if they want.
- IDC users cannot use this flow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
