### PR TITLE
Fix: mcp client background task entering a hot loop on child process crash

### DIFF
--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -362,6 +362,16 @@ where
                     },
                     Err(e) => {
                         tracing::error!("Background listening thread for client {}: {:?}", server_name, e);
+                        // If we don't have anything on the other end, we should just end the task
+                        // now
+                        if let TransportError::RecvError(tokio::sync::broadcast::error::RecvError::Closed) = e {
+                            tracing::error!(
+                                "All senders dropped for transport layer for server {}: {:?}. This likely means the mcp server process is no longer running.",
+                                server_name,
+                                e
+                            );
+                            break;
+                        }
                     },
                 }
             }

--- a/crates/chat-cli/src/mcp_client/transport/stdio.rs
+++ b/crates/chat-cli/src/mcp_client/transport/stdio.rs
@@ -51,7 +51,7 @@ impl JsonRpcStdioTransport {
                 // Messages are delimited by newlines and assumed to contain no embedded newlines
                 // See https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio
                 match buf_reader.read_until(b'\n', &mut buffer).await {
-                    Ok(0) => continue,
+                    Ok(0) => break,
                     Ok(_) => match serde_json::from_slice::<JsonRpcMessage>(buffer.as_slice()) {
                         Ok(msg) => {
                             let _ = tx.send(Ok(msg));


### PR DESCRIPTION
*Issue #, if available:*
Users report: 
- _Sometimes_ q cli will run hot, taking up high CPU usage.
- Observed along with this high CPU usage is a failure for some MCP servers to load. Though this observation is only made by one user. And it is not made certain due to a lack of consistent reproducible examples. 
- The reporting users did produce sample logs, but the references are mangled and only shows the llvm optimized hash. 

_One of_ the potential causes for the hot loop is in the background tasks spawned to listen for incoming messages from the server. The fix here is to condition the loop in such a way that they end once the child process no longer exists.  

This is confirmed by killing all Q CLI's child processes, and subsequently we can observe that the CPU usage for q chat sky rockets. 

*Description of changes:*
- Break loop on EOF in the transport layer
- Break loop on channel closed in the client layer 

*Test:*
- `ps aux | grep -i "chat"` and find the PID
- `pstree -p $PID`, observe that there are child processes that are mcp servers
- `kill -9 $CHILD#1PID, CHILD#2PID, ...`
- Observe that the CPU no longer spikes
- Also observed are the logging messages added present in the log

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
