### PR TITLE
fix: remove 30 second check when receiving invalid json from the model

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3337,38 +3337,12 @@ impl ChatContext {
                             tool_use_id,
                             name,
                             message,
-                            time_elapsed,
+                            ..
                         } => {
                             error!(
                                 recv_error.request_id,
                                 tool_use_id, name, "The response stream ended before the entire tool use was received"
                             );
-                            if self.interactive {
-                                drop(self.spinner.take());
-                                queue!(
-                                    self.output,
-                                    terminal::Clear(terminal::ClearType::CurrentLine),
-                                    cursor::MoveToColumn(0),
-                                    style::SetForegroundColor(Color::Yellow),
-                                    style::SetAttribute(Attribute::Bold),
-                                    style::Print(format!(
-                                        "Warning: received an unexpected error from the model after {:.2}s",
-                                        time_elapsed.as_secs_f64()
-                                    )),
-                                )?;
-                                if let Some(request_id) = recv_error.request_id {
-                                    queue!(
-                                        self.output,
-                                        style::Print(format!("\n         request_id: {}", request_id))
-                                    )?;
-                                }
-                                execute!(self.output, style::Print("\n\n"), style::SetAttribute(Attribute::Reset))?;
-                                self.spinner = Some(Spinner::new(
-                                    Spinners::Dots,
-                                    "Trying to divide up the work...".to_string(),
-                                ));
-                            }
-
                             self.conversation_state.push_assistant_message(*message, database);
                             let tool_results = vec![ToolUseResult {
                                     tool_use_id,

--- a/crates/chat-cli/src/cli/chat/parser.rs
+++ b/crates/chat-cli/src/cli/chat/parser.rs
@@ -202,7 +202,6 @@ impl ResponseParser {
                 // If we failed deserializing after waiting for a long time, then this is most
                 // likely bedrock responding with a stop event for some reason without actually
                 // including the tool contents. Essentially, the tool was too large.
-                // Timeouts have been seen as short as ~1 minute, so setting the time to 30.
                 let time_elapsed = start.elapsed();
                 let args = serde_json::Value::Object(
                     [(
@@ -214,7 +213,7 @@ impl ResponseParser {
                     .into_iter()
                     .collect(),
                 );
-                if self.peek().await?.is_none() && time_elapsed > Duration::from_secs(30) {
+                if self.peek().await?.is_none() {
                     error!(
                         "Received an unexpected end of stream after spending ~{}s receiving tool events",
                         time_elapsed.as_secs_f64()


### PR DESCRIPTION
*Description of changes:*
- Remove the 30 second check when we receive invalid JSON from the model, since Sonnet v4 seems to return invalid JSON relatively often under 30 seconds. Now, we will always retry the request, and not display the error to the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
