### PR TITLE
Revert "UX Fix for hard to distinguish between user and assistant responses (#130)"

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1399,9 +1399,10 @@ impl ChatContext {
                 self.send_tool_use_telemetry(telemetry).await;
 
                 if self.interactive {
-                    // Print newlines before starting the assistant response
-                    execute!(self.output, style::Print("\n\n"))?;
+                    queue!(self.output, style::SetForegroundColor(Color::Magenta))?;
+                    queue!(self.output, style::SetForegroundColor(Color::Reset))?;
                     queue!(self.output, cursor::Hide)?;
+                    execute!(self.output, style::Print("\n"))?;
                     self.spinner = Some(Spinner::new(Spinners::Dots, "Thinking...".to_owned()));
                 }
 
@@ -3234,18 +3235,6 @@ impl ChatContext {
                 cursor::Show,
                 cursor::MoveUp(1),
                 terminal::Clear(terminal::ClearType::CurrentLine),
-            )?;
-        }
-
-        // Add assistant indicator at the beginning of the response
-        if self.interactive {
-            queue!(
-                self.output,
-                style::SetForegroundColor(Color::Yellow),
-                style::SetAttribute(Attribute::Bold),
-                style::Print("Amazon Q > "),
-                style::SetAttribute(Attribute::Reset),
-                style::SetForegroundColor(Color::Reset),
             )?;
         }
 

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -87,7 +87,7 @@ pub fn generate_prompt(current_profile: Option<&str>, warning: bool) -> String {
         .map(|p| format!("[{p}] ").cyan().to_string())
         .unwrap_or_default();
 
-    format!("{profile_part}{warning_symbol}{}", "> ".cyan().bold())
+    format!("{profile_part}{warning_symbol}{}", "> ".magenta())
 }
 
 /// Complete commands that start with a slash
@@ -310,23 +310,20 @@ mod tests {
     #[test]
     fn test_generate_prompt() {
         // Test default prompt (no profile)
-        assert_eq!(generate_prompt(None, false), "> ".cyan().bold().to_string());
+        assert_eq!(generate_prompt(None, false), "> ".magenta().to_string());
         // Test default prompt with warning
-        assert_eq!(
-            generate_prompt(None, true),
-            format!("{}{}", "!".red(), "> ".cyan().bold())
-        );
+        assert_eq!(generate_prompt(None, true), format!("{}{}", "!".red(), "> ".magenta()));
         // Test default profile (should be same as no profile)
-        assert_eq!(generate_prompt(Some("default"), false), "> ".cyan().bold().to_string());
+        assert_eq!(generate_prompt(Some("default"), false), "> ".magenta().to_string());
         // Test custom profile
         assert_eq!(
             generate_prompt(Some("test-profile"), false),
-            format!("{}{}", "[test-profile] ".cyan(), "> ".cyan().bold())
+            format!("{}{}", "[test-profile] ".cyan(), "> ".magenta())
         );
         // Test another custom profile with warning
         assert_eq!(
             generate_prompt(Some("dev"), true),
-            format!("{}{}{}", "[dev] ".cyan(), "!".red(), "> ".cyan().bold())
+            format!("{}{}{}", "[dev] ".cyan(), "!".red(), "> ".magenta())
         );
     }
 


### PR DESCRIPTION
This reverts commit e7ed28fe121ae1a2dd99f681d2daf084262238df.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
