### PR TITLE
fix: qchat launch logic on linux to fallback to a global qchat

### DIFF
--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -595,7 +595,15 @@ fn qchat_path() -> Result<PathBuf> {
             return Ok(PathBuf::from("/usr/bin").join(CHAT_BINARY_NAME));
         }
     }
-    Ok(home_local_bin()?.join(CHAT_BINARY_NAME))
+
+    if let Ok(local_bin_path) = home_local_bin() {
+        let local_bin_path = local_bin_path.join(CHAT_BINARY_NAME);
+        if local_bin_path.exists() {
+            return Ok(local_bin_path);
+        }
+    }
+
+    Ok(PathBuf::from(CHAT_BINARY_NAME))
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
*Issue #, if available:* #168

*Description of changes:*
- Updating the qchat launch logic to fallback to a global `qchat` on the path if it is not found in `/usr/bin` or `~/.local/bin`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
