### PR TITLE
Updated with new feature for fs_write which shows 'summary of change'

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -111,6 +111,10 @@
         "path": {
           "description": "Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.",
           "type": "string"
+        },
+        "summary": {
+          "description": "A brief explanation of what the file change does or why it's being made.",
+          "type": "string"
         }
       },
       "required": ["command", "path"]


### PR DESCRIPTION
# Pull Request: Add Summary of Change Feature to fs_write Tool

## Description

This PR adds a new "Summary of Change" feature to the fs_write tool in Amazon Q CLI. This enhancement allows the LLM to provide a concise 
explanation of what a file change does or why it's being made, improving user understanding and code documentation.

The summary is displayed after the diff output in a visually distinct format, making it easy for users to understand the purpose of file 
modifications without having to analyze the code changes themselves.

## Changes Made

1. Added a new optional summary parameter to all fs_write command variants (create, str_replace, insert, append)
2. Updated the tool_index.json schema to include the new parameter with appropriate description
3. Added a get_summary() helper method to extract the summary from any variant of the FsWrite enum
4. Implemented display logic to show the summary after the diff output with appropriate formatting
5. Added unit tests to verify the summary display functionality


<img width="830" alt="Screenshot 2025-06-10 at 2 46 46 PM" src="https://github.com/user-attachments/assets/ca2c1dde-8fec-486f-8e21-3a0d6027be39" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
