### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,14 +60,14 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bitflags 2.9.1",
  "camino",
  "serde",
  "serde_json",
  "serde_yaml",
- "shell-color 1.11.0",
+ "shell-color 1.12.0",
  "tracing",
  "unicode-width 0.2.0",
  "vte 0.15.0",
@@ -259,7 +259,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bindgen 0.71.1",
  "objc",
@@ -1461,7 +1461,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chat_cli"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2210,7 +2210,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dbus"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "cfg-if",
  "clap",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "apple-bundle",
  "fig_ipc",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "fig_util",
  "parking_lot",
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "cfg-if",
  "dirs 5.0.1",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "fd-lock",
  "fig_test",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry-client",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry-client",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "fig_test_macro",
  "tokio",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_utils"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bytes",
  "fig_os_shim",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared_library",
- "shell-color 1.11.0",
+ "shell-color 1.12.0",
  "shell-words",
  "shellexpand",
  "shlex",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6958,7 +6958,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -8158,7 +8158,7 @@ dependencies = [
 
 [[package]]
 name = "shell-color"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bitflags 2.9.1",
  "fig_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 edition = "2021"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.11.0"
+version = "1.12.0"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -12,6 +12,22 @@
     },
     {
       "type": "release",
+      "date": "2025-06-11",
+      "version": "1.12.0",
+      "title": "Version 1.12.0",
+      "changes": [
+        {
+          "type": "added",
+          "description": "Support for upgrading to a pro subscription with `/subscribe` in `q chat` - [#143](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/143)"
+        },
+        {
+          "type": "fixed",
+          "description": "`q chat` failing to launch in some Linux installations - [#169](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/169)"
+        }
+      ]
+    },
+    {
+      "type": "release",
       "date": "2025-06-04",
       "version": "1.11.0",
       "title": "Version 1.11.0",


### PR DESCRIPTION
*Description of changes:*
- Bumping the version to `1.12.0` and adding `feed.json` entries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
