### PR TITLE
Fix MCP logging

### DIFF
--- a/crates/chat-cli/src/logging.rs
+++ b/crates/chat-cli/src/logging.rs
@@ -76,7 +76,7 @@ pub fn initialize_logging<T: AsRef<Path>>(args: LogArgs<T>) -> Result<LogGuard, 
 
             // Make the log path parent directory if it doesn't exist.
             if let Some(parent) = log_path.parent() {
-                if log_path.ends_with("chat.log") {
+                if log_path.ends_with("qchat.log") {
                     mcp_path = Some(parent.to_path_buf());
                 }
                 std::fs::create_dir_all(parent)?;

--- a/crates/fig_log/src/lib.rs
+++ b/crates/fig_log/src/lib.rs
@@ -75,7 +75,7 @@ pub fn initialize_logging<T: AsRef<Path>>(args: LogArgs<T>) -> Result<LogGuard, 
 
             // Make the log path parent directory if it doesn't exist.
             if let Some(parent) = log_path.parent() {
-                if log_path.ends_with("chat.log") {
+                if log_path.ends_with("qchat.log") {
                     mcp_path = Some(parent.to_path_buf());
                 }
                 std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
*Description of changes:*
 
The default log file path [was updated](https://github.com/aws/amazon-q-developer-cli-autocomplete/blame/0a835b7e18cd50febc7fea95d1798fec3f99be96/crates/chat-cli/src/cli/mod.rs#L187) but wasn't updated in other logging files, causing the MCP logging not to be initialized properly. 

There's also another log file being created in the code for the q cli binary [here](https://github.com/aws/amazon-q-developer-cli-autocomplete/blob/0a835b7e18cd50febc7fea95d1798fec3f99be96/crates/q_cli/src/cli/mod.rs#L308), not sure if that should be updated too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
