### PR TITLE
Fix: Allow --trust-tools to work on MCP servers

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -6,7 +6,10 @@ pub mod gh_issue;
 pub mod thinking;
 pub mod use_aws;
 
-use std::collections::HashMap;
+use std::collections::{
+    HashMap,
+    HashSet,
+};
 use std::io::Write;
 use std::path::{
     Path,
@@ -128,6 +131,8 @@ pub struct ToolPermissions {
     // We need this field for any stragglers
     pub trust_all: bool,
     pub permissions: HashMap<String, ToolPermission>,
+    // Store pending trust-tool patterns for MCP tools that may be loaded later
+    pub pending_trusted_tools: HashSet<String>,
 }
 
 impl ToolPermissions {
@@ -135,23 +140,29 @@ impl ToolPermissions {
         Self {
             trust_all: false,
             permissions: HashMap::with_capacity(capacity),
+            pending_trusted_tools: HashSet::new(),
         }
     }
 
-    pub fn is_trusted(&self, tool_name: &str) -> bool {
+    pub fn is_trusted(&mut self, tool_name: &str) -> bool {
+        // Check if we should trust from pending patterns first
+        if self.should_trust_from_pending(tool_name) {
+            self.trust_tool(tool_name);
+            self.pending_trusted_tools.remove(tool_name);
+        }
+
         self.trust_all || self.permissions.get(tool_name).is_some_and(|perm| perm.trusted)
     }
 
     /// Returns a label to describe the permission status for a given tool.
-    pub fn display_label(&self, tool_name: &str) -> String {
-        if self.has(tool_name) || self.trust_all {
-            if self.is_trusted(tool_name) {
-                format!("  {}", "trusted".dark_green().bold())
-            } else {
-                format!("  {}", "not trusted".dark_grey())
-            }
-        } else {
-            self.default_permission_label(tool_name)
+    pub fn display_label(&mut self, tool_name: &str) -> String {
+        let is_trusted = self.is_trusted(tool_name);
+        let has_setting = self.has(tool_name) || self.trust_all;
+
+        match (has_setting, is_trusted) {
+            (true, true) => format!("  {}", "trusted".dark_green().bold()),
+            (true, false) => format!("  {}", "not trusted".dark_grey()),
+            _ => self.default_permission_label(tool_name),
         }
     }
 
@@ -162,6 +173,7 @@ impl ToolPermissions {
 
     pub fn untrust_tool(&mut self, tool_name: &str) {
         self.trust_all = false;
+        self.pending_trusted_tools.remove(tool_name);
         self.permissions
             .insert(tool_name.to_string(), ToolPermission { trusted: false });
     }
@@ -169,14 +181,33 @@ impl ToolPermissions {
     pub fn reset(&mut self) {
         self.trust_all = false;
         self.permissions.clear();
+        self.pending_trusted_tools.clear();
     }
 
     pub fn reset_tool(&mut self, tool_name: &str) {
         self.trust_all = false;
         self.permissions.remove(tool_name);
+        self.pending_trusted_tools.remove(tool_name);
     }
 
-    pub fn has(&self, tool_name: &str) -> bool {
+    /// Add a pending trust pattern for tools that may be loaded later
+    pub fn add_pending_trust_tool(&mut self, pattern: String) {
+        self.pending_trusted_tools.insert(pattern);
+    }
+
+    /// Check if a tool should be trusted based on preceding trust declarations
+    pub fn should_trust_from_pending(&self, tool_name: &str) -> bool {
+        // Check for exact match
+        self.pending_trusted_tools.contains(tool_name)
+    }
+
+    pub fn has(&mut self, tool_name: &str) -> bool {
+        // Check if we should trust from pending tools first
+        if self.should_trust_from_pending(tool_name) {
+            self.trust_tool(tool_name);
+            self.pending_trusted_tools.remove(tool_name);
+        }
+
         self.permissions.contains_key(tool_name)
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Currently if you call `--trust-tools` with tools that will be vended by MCP servers, the configuration doesn't take effect if the server takes too long to start.

Reproduction steps:
1. Run `q chat --trust-tools=<tool>` (e.g. `clear_thought___sequentialthinking`)
2. Wait for the MCP server to start up
3. Run `/tools` to check trust status
4. Validate the (incorrectly untrusted) trust status by asking Q to run the tool for some trivial purpose.

Port of https://github.com/aws/amazon-q-developer-cli/pull/2039 to this older repository, since it's unclear which one of them is currently the site of active development.

*Description of changes:*
EDIT: FYI, this code is largely Q-CLI written, as I'm not an experienced Rust coder. I've tried to ensure it matches the expected style conventions and minimized code-changes, but please make sure it's up to this repository's standards.

This PR modifies the `ToolPermissions` implementation to track tools from the `--trust-tools` config that don't exist yet, and triggers adding them to `permissions` when they're available. It also configures `untrust_tool` to modify this pending config as well as `permissions`, to avoid edge-cases where a tool can't be untrusted due to being in the pending list.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Disclaimer: Any opinions or communications in this pull request are entirely my own, and do not reflect those of AWS or its other employees.