### PR TITLE
chore: Add instructions on how to invoke `/prompts`

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -416,7 +416,7 @@ const SMALL_SCREEN_WELCOME_TEXT: &str = color_print::cstr! {"<em>Welcome to <cya
 const RESUME_TEXT: &str = color_print::cstr! {"<em>Picking up where we left off...</em>"};
 
 // Only show the model-related tip for now to make users aware of this feature.
-const ROTATING_TIPS: [&str; 2] = [
+const ROTATING_TIPS: [&str; 3] = [
     // color_print::cstr! {"You can resume the last conversation from your current directory by launching with
     // <green!>q chat --resume</green!>"}, color_print::cstr! {"Get notified whenever Q CLI finishes responding.
     // Just run <green!>q settings chat.enableNotifications true</green!>"}, color_print::cstr! {"You can use
@@ -437,6 +437,7 @@ const ROTATING_TIPS: [&str; 2] = [
     // warnings or errors associated with <green!>/mcp</green!>"},
     color_print::cstr! {"Use <green!>/model</green!> to select the model to use for this conversation"},
     color_print::cstr! {"Set a default model by running <green!>q settings chat.defaultModel MODEL</green!>. Run <green!>/model</green!> to learn more."},
+    color_print::cstr! {"Run <green!>/prompts</green!> to learn how to build & run repeatable workflows"},
 ];
 
 pub struct ModelOption {
@@ -2856,6 +2857,21 @@ impl ChatContext {
                                 optimal_case
                             }
                         };
+                        // Add usage guidance at the top
+                        queue!(
+                            self.output,
+                            style::Print("\n"),
+                            style::SetAttribute(Attribute::Bold),
+                            style::Print("Usage: "),
+                            style::SetAttribute(Attribute::Reset),
+                            style::Print("You can use a prompt by typing "),
+                            style::SetAttribute(Attribute::Bold),
+                            style::SetForegroundColor(Color::Green),
+                            style::Print("'@<prompt name> [...args]'"),
+                            style::SetForegroundColor(Color::Reset),
+                            style::SetAttribute(Attribute::Reset),
+                            style::Print("\n\n"),
+                        )?;
                         queue!(
                             self.output,
                             style::Print("\n"),


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/1764

*Description of changes:*
 Add instructions on how to invoke `/prompts` and tip
### before:
![image](https://github.com/user-attachments/assets/b1d96122-5e5a-4d78-8189-39d7681eb4ef)

### after:
![Screenshot 2025-06-11 at 3 32 18 PM](https://github.com/user-attachments/assets/c1a7d281-1536-4dfb-aa11-ba616e4e825d)
![Screenshot 2025-06-11 at 3 35 31 PM](https://github.com/user-attachments/assets/5b1baeac-001e-494f-8959-589fd17e00eb)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
