### PR TITLE
chore: Switch chat default model to Claude Sonnet 4

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -459,7 +459,7 @@ pub const MODEL_OPTIONS: [ModelOption; 3] = [
     },
 ];
 
-pub const DEFAULT_MODEL_ID: &str = "CLAUDE_3_7_SONNET_20250219_V1_0";
+pub const DEFAULT_MODEL_ID: &str = "CLAUDE_SONNET_4_20250514_V1_0";
 
 const GREETING_BREAK_POINT: usize = 80;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Switching CLI default to S4 allows us to balance load more efficiently and utilize available resources. Fallback behavior remains unchanged — clients can still explicitly select other models as needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
