### PR TITLE
Fix: prompt denial reason upon tool use denial

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -4571,11 +4571,13 @@ mod tests {
                 "/tools untrust fs_write".to_string(),
                 "create a file".to_string(), // prompt again due to untrust
                 "n".to_string(),             // cancel
+                "no reason".to_string(),     // dummy reason
                 "/tools trust fs_write".to_string(),
                 "create a file".to_string(), // again without prompting due to '/tools trust'
                 "/tools reset".to_string(),
                 "create a file".to_string(), // prompt again due to reset
                 "n".to_string(),             // cancel
+                "no reason".to_string(),     // dummy reason
                 "exit".to_string(),
             ]),
             true,

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1573,22 +1573,23 @@ impl ChatContext {
                         tool_use.accepted = true;
 
                         return Ok(ChatState::ExecuteTools(tool_uses));
-                    // Prompt reason if no selected 
+                    // Prompt reason if no selected
                     } else if tool_denied_without_reason {
                         tool_use.accepted = false;
                         execute!(
                             self.output,
                             style::SetForegroundColor(Color::DarkGrey),
-                            style::Print("\nPlease provide a reason for denying this tool use, or otherwise continue your conversation:\n\n"),
+                            style::Print(
+                                "\nPlease provide a reason for denying this tool use, or otherwise continue your conversation:\n\n"
+                            ),
                             style::SetForegroundColor(Color::Reset),
                         )?;
 
                         return Ok(ChatState::PromptUser {
                             tool_uses: Some(tool_uses),
-                            pending_tool_index: pending_tool_index,
+                            pending_tool_index,
                             skip_printing_tools: true,
                         });
-                        
                     }
                 } else if !self.pending_prompts.is_empty() {
                     let prompts = self.pending_prompts.drain(0..).collect();
@@ -1601,11 +1602,11 @@ impl ChatContext {
                 // Otherwise continue with normal chat on 'n' or other responses
                 self.tool_use_status = ToolUseStatus::Idle;
                 if pending_tool_index.is_some() {
-                        self.conversation_state.abandon_tool_use(tool_uses, user_input);
+                    self.conversation_state.abandon_tool_use(tool_uses, user_input);
                 } else {
                     self.conversation_state.set_next_user_message(user_input).await;
                 }
-                
+
                 let conv_state = self.conversation_state.as_sendable_conversation_state(true).await;
                 self.send_tool_use_telemetry(telemetry).await;
 

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1562,6 +1562,7 @@ impl ChatContext {
         Ok(match command {
             Command::Ask { prompt } => {
                 // Check for a pending tool approval
+                let mut reason_prompt= String::from("Tool denied: ");
                 if let Some(index) = pending_tool_index {
                     let tool_use = &mut tool_uses[index];
 
@@ -1573,6 +1574,21 @@ impl ChatContext {
                         tool_use.accepted = true;
 
                         return Ok(ChatState::ExecuteTools(tool_uses));
+                    // Prompt reason if no selected 
+                    } else if ["n", "N"].contains(&prompt.as_str()) {
+                        tool_use.accepted = false;
+                        execute!(
+                            self.output,
+                            style::SetForegroundColor(Color::DarkGrey),
+                            style::Print("\nPlease provide a reason for denying this tool use:\n\n"),
+                            style::SetForegroundColor(Color::Reset),
+                        )?;
+                        let reason: String = match self.read_user_input("> ".yellow().to_string().as_str(), true) {
+                            Some(input) if !input.trim().is_empty() => input,
+                            _ => "No reason provided".to_string(),
+                        };
+                        reason_prompt.push_str(&reason);
+                        reason_prompt.push_str(". Take user feedback and try again if reason provided, else continue conversation.");
                     }
                 } else if !self.pending_prompts.is_empty() {
                     let prompts = self.pending_prompts.drain(0..).collect();
@@ -1584,13 +1600,16 @@ impl ChatContext {
 
                 // Otherwise continue with normal chat on 'n' or other responses
                 self.tool_use_status = ToolUseStatus::Idle;
-
                 if pending_tool_index.is_some() {
-                    self.conversation_state.abandon_tool_use(tool_uses, user_input);
+                    if ["n", "N"].contains(&prompt.as_str()) {
+                        self.conversation_state.abandon_tool_use(tool_uses, reason_prompt);
+                    } else {
+                        self.conversation_state.abandon_tool_use(tool_uses, user_input);
+                    }
                 } else {
                     self.conversation_state.set_next_user_message(user_input).await;
                 }
-
+                
                 let conv_state = self.conversation_state.as_sendable_conversation_state(true).await;
                 self.send_tool_use_telemetry(telemetry).await;
 


### PR DESCRIPTION
Description of changes: User is now prompted for reason upon denying tool use. Allows model to gather more information rather than just 'n.' 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
