### PR TITLE
fix: `/compact` validation error: missing tool specs

### DIFF
--- a/crates/chat-cli/src/cli/chat/conversation_state.rs
+++ b/crates/chat-cli/src/cli/chat/conversation_state.rs
@@ -70,6 +70,10 @@ use crate::api_client::model::{
     UserInputMessageContext,
 };
 use crate::cli::chat::util::shared_writer::SharedWriter;
+use crate::cli::chat::{
+    TokenCount,
+    TokenCounter,
+};
 use crate::database::Database;
 use crate::mcp_client::Prompt;
 use crate::platform::Context;
@@ -600,9 +604,20 @@ impl ConversationState {
             flatten_history(conv_state.history.take(history_len.saturating_sub(1)))
         };
 
+        let user_input_message_context = UserInputMessageContext {
+            env_state: Some(build_env_state()),
+            git_state: None,
+            tool_results: None,
+            tools: if self.tools.is_empty() {
+                None
+            } else {
+                Some(self.tools.values().flatten().cloned().collect::<Vec<Tool>>())
+            },
+        };
+
         let mut summary_message = UserInputMessage {
             content: summary_content,
-            user_input_message_context: None,
+            user_input_message_context: Some(user_input_message_context),
             user_intent: None,
             images: None,
             model_id: self.model.clone(),

--- a/crates/chat-cli/src/cli/chat/conversation_state.rs
+++ b/crates/chat-cli/src/cli/chat/conversation_state.rs
@@ -70,10 +70,6 @@ use crate::api_client::model::{
     UserInputMessageContext,
 };
 use crate::cli::chat::util::shared_writer::SharedWriter;
-use crate::cli::chat::{
-    TokenCount,
-    TokenCounter,
-};
 use crate::database::Database;
 use crate::mcp_client::Prompt;
 use crate::platform::Context;

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -2973,8 +2973,7 @@ impl ChatContext {
                 }
 
                 let data = state.calculate_conversation_size();
-                let tool_specs_json: String = self
-                    .conversation_state
+                let tool_specs_json: String = state
                     .tools
                     .values()
                     .filter_map(|s| serde_json::to_string(s).ok())

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -161,6 +161,7 @@ use crate::api_client::{
 };
 use crate::auth::AuthError;
 use crate::auth::builder_id::is_idc_user;
+use crate::cli::chat::token_counter::CharCount;
 use crate::database::Database;
 use crate::database::settings::Setting;
 use crate::mcp_client::{
@@ -2972,24 +2973,20 @@ impl ChatContext {
                 }
 
                 let data = state.calculate_conversation_size();
+                let tool_specs_json: String = self
+                    .conversation_state
+                    .tools
+                    .values()
+                    .filter_map(|s| serde_json::to_string(s).ok())
+                    .collect();
 
                 let context_token_count: TokenCount = data.context_messages.into();
                 let assistant_token_count: TokenCount = data.assistant_messages.into();
                 let user_token_count: TokenCount = data.user_messages.into();
-                let mcp_token_count: TokenCount = TokenCounter::count_tokens(
-                    &self
-                        .conversation_state
-                        .tools
-                        .values()
-                        .filter_map(|s| serde_json::to_string(s).ok())
-                        .collect::<String>(),
-                )
-                .into();
-                let total_token_used: TokenCount = (context_token_count.value()
-                    + assistant_token_count.value()
-                    + user_token_count.value()
-                    + mcp_token_count.value())
-                .into();
+                let tools_char_count: CharCount = tool_specs_json.len().into(); // usize → CharCount
+                let tools_token_count: TokenCount = tools_char_count.into(); // CharCount → TokenCount
+                let total_token_used: TokenCount =
+                    (data.context_messages + data.user_messages + data.assistant_messages + tools_char_count).into();
                 let window_width = self.terminal_width();
                 // set a max width for the progress bar for better aesthetic
                 let progress_bar_width = std::cmp::min(window_width, 80);
@@ -2998,18 +2995,18 @@ impl ChatContext {
                     * progress_bar_width as f64) as usize;
                 let assistant_width = ((assistant_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64)
                     * progress_bar_width as f64) as usize;
-                let mcp_width = ((mcp_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64)
+                let tools_width = ((tools_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64)
                     * progress_bar_width as f64) as usize;
                 let user_width = ((user_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64)
                     * progress_bar_width as f64) as usize;
 
                 let left_over_width = progress_bar_width
                     - std::cmp::min(
-                        context_width + assistant_width + user_width + mcp_width,
+                        context_width + assistant_width + user_width + tools_width,
                         progress_bar_width,
                     );
 
-                let is_overflow = (context_width + assistant_width + user_width + mcp_width) > progress_bar_width;
+                let is_overflow = (context_width + assistant_width + user_width + tools_width) > progress_bar_width;
 
                 if is_overflow {
                     queue!(
@@ -3046,10 +3043,14 @@ impl ChatContext {
                             0
                         })),
                         style::Print("█".repeat(context_width)),
-                        // MCP tools
+                        // Tools
                         style::SetForegroundColor(Color::DarkRed),
-                        style::Print("|".repeat(if mcp_width == 0 && *mcp_token_count > 0 { 1 } else { 0 })),
-                        style::Print("█".repeat(mcp_width)),
+                        style::Print("|".repeat(if tools_width == 0 && *tools_token_count > 0 {
+                            1
+                        } else {
+                            0
+                        })),
+                        style::Print("█".repeat(tools_width)),
                         // Assistant responses
                         style::SetForegroundColor(Color::Blue),
                         style::Print("|".repeat(if assistant_width == 0 && *assistant_token_count > 0 {
@@ -3087,12 +3088,12 @@ impl ChatContext {
                         (context_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
                     )),
                     style::SetForegroundColor(Color::DarkRed),
-                    style::Print("█ MCP tools:    "),
+                    style::Print("█ Tools:    "),
                     style::SetForegroundColor(Color::Reset),
                     style::Print(format!(
                         " ~{} tokens ({:.2}%)\n",
-                        mcp_token_count,
-                        (mcp_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                        tools_token_count,
+                        (tools_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
                     )),
                     style::SetForegroundColor(Color::Blue),
                     style::Print("█ Q responses: "),

--- a/crates/chat-cli/src/cli/chat/token_counter.rs
+++ b/crates/chat-cli/src/cli/chat/token_counter.rs
@@ -75,7 +75,7 @@ impl std::fmt::Display for TokenCount {
 pub struct TokenCounter;
 
 impl TokenCounter {
-    pub const TOKEN_TO_CHAR_RATIO: usize = 3;
+    pub const TOKEN_TO_CHAR_RATIO: usize = 4;
 
     /// Estimates the number of tokens in the input content.
     /// Currently uses a simple heuristic: content length / TOKEN_TO_CHAR_RATIO

--- a/crates/chat-cli/src/cli/chat/token_counter.rs
+++ b/crates/chat-cli/src/cli/chat/token_counter.rs
@@ -72,6 +72,12 @@ impl std::fmt::Display for TokenCount {
     }
 }
 
+impl From<usize> for TokenCount {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
 pub struct TokenCounter;
 
 impl TokenCounter {

--- a/crates/chat-cli/src/cli/chat/token_counter.rs
+++ b/crates/chat-cli/src/cli/chat/token_counter.rs
@@ -72,12 +72,6 @@ impl std::fmt::Display for TokenCount {
     }
 }
 
-impl From<usize> for TokenCount {
-    fn from(value: usize) -> Self {
-        Self(value)
-    }
-}
-
 pub struct TokenCounter;
 
 impl TokenCounter {

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -87,10 +87,6 @@ use crate::cli::chat::tools::{
     ToolOrigin,
     ToolSpec,
 };
-use crate::cli::chat::{
-    TokenCount,
-    TokenCounter,
-};
 use crate::database::Database;
 use crate::database::settings::Setting;
 use crate::mcp_client::{
@@ -1240,25 +1236,6 @@ impl ToolManager {
 
     pub async fn pending_clients(&self) -> Vec<String> {
         self.pending_clients.read().await.iter().cloned().collect::<Vec<_>>()
-    }
-
-    pub fn tool_token_count(&self) -> TokenCount {
-        // empty early‑exit
-        if self.schema.is_empty() {
-            return 0usize.into();
-        }
-
-        // Concat all tool specs as JSON
-        let mut combined = String::new();
-        for spec in self.schema.values() {
-            if let Ok(s) = serde_json::to_string(spec) {
-                combined.push_str(&s);
-            }
-        }
-
-        //  Run through the same tokenizer used elsewhere in chat
-        let cnt = TokenCounter::count_tokens(&combined);
-        cnt.into()
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -87,6 +87,10 @@ use crate::cli::chat::tools::{
     ToolOrigin,
     ToolSpec,
 };
+use crate::cli::chat::{
+    TokenCount,
+    TokenCounter,
+};
 use crate::database::Database;
 use crate::database::settings::Setting;
 use crate::mcp_client::{
@@ -1236,6 +1240,25 @@ impl ToolManager {
 
     pub async fn pending_clients(&self) -> Vec<String> {
         self.pending_clients.read().await.iter().cloned().collect::<Vec<_>>()
+    }
+
+    pub fn tool_token_count(&self) -> TokenCount {
+        // empty early‑exit
+        if self.schema.is_empty() {
+            return 0usize.into();
+        }
+
+        // Concat all tool specs as JSON
+        let mut combined = String::new();
+        for spec in self.schema.values() {
+            if let Ok(s) = serde_json::to_string(spec) {
+                combined.push_str(&s);
+            }
+        }
+
+        //  Run through the same tokenizer used elsewhere in chat
+        let cnt = TokenCounter::count_tokens(&combined);
+        cnt.into()
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/util/mod.rs
+++ b/crates/chat-cli/src/cli/chat/util/mod.rs
@@ -189,7 +189,7 @@ mod tests {
                 "Yet another test file that's has the largest context file".to_string(),
             ),
         ];
-        let limit = 10;
+        let limit = 9;
 
         let dropped_files = drop_matched_context_files(&mut files, limit).unwrap();
         assert_eq!(dropped_files.len(), 1);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/2044

### Problem
1.` /compact` would fail with ToolUse has no corresponding tool spec.
Steps to reproduce:
Use fs_read tool to read an image via Q CLI
Send a random message to ensure a conversation history is established
Run /compact
❌ You’ll see a validation error due to the missing tool spec in the summary request
![Screenshot 2025-06-12 at 5 36 04 PM](https://github.com/user-attachments/assets/e2dae23b-1e2b-4cc1-9caf-df6638987090)

2. The `/usage` command does not account for token space used by tool specs from configured MCP servers, which could be large.

### *Description of changes:*
This PR includes two related improvements:
1. `/compact` always includes tool specs (and cancels dangling tool-uses)
- Add tools field in `UserInputMessageContext` when generating summary request.

2. `/usage` now counts tool specs accurately (built in + mcp tools)
- Uses `conversation_state.tools` (post-permission filter) to build a single JSON string and runs it through existing `TokenCounter`.
- Adds the result to the MCP line in the progress bar for a true prompt-size estimate.
<img width="633" alt="Screenshot 2025-06-13 at 2 41 57 PM" src="https://github.com/user-attachments/assets/a1858596-4c19-4df4-8ee1-ec8ffc08a559" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
