### PR TITLE
fix: reduce maximum tool use response size to 400,000

### DIFF
--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -8,10 +8,10 @@ pub const MAX_CURRENT_WORKING_DIRECTORY_LEN: usize = 256;
 pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 250;
 
 /// Actual service limit is 800_000
-pub const MAX_TOOL_RESPONSE_SIZE: usize = 600_000;
+pub const MAX_TOOL_RESPONSE_SIZE: usize = 400_000;
 
 /// Actual service limit is 600_000
-pub const MAX_USER_MESSAGE_SIZE: usize = 600_000;
+pub const MAX_USER_MESSAGE_SIZE: usize = 400_000;
 
 /// In tokens
 pub const CONTEXT_WINDOW_SIZE: usize = 200_000;


### PR DESCRIPTION
*Description of changes:*
- Currently tool uses can overflow the context window with a single message, causing `/compact` to fail in the scenario where there is only a single large tool use in the conversation history. Therefore, reducing the maximum size to `400_000` characters instead
- Sonnet 3.5/3.7/4.0 all have a size of 200k tokens, so 400k characters should reduce the number of times we hit this edge case - https://docs.anthropic.com/en/docs/about-claude/models/overview#model-comparison-table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
