### PR TITLE
feat(mcp): Implement MCP resources support

### DIFF
--- a/crates/chat-cli/src/cli/chat/command.rs
+++ b/crates/chat-cli/src/cli/chat/command.rs
@@ -895,10 +895,8 @@ impl Command {
                                     }),
                                 },
                                 None => {
-                                    return Err(ResourcesSubcommand::usage_msg(
-                                        "URI is required for read command".to_string(),
-                                    ));
-                                }
+                                    return Err(ResourcesSubcommand::usage_msg("URI is required for read command"));
+                                },
                             }
                         },
                         Some(c) if c.to_lowercase() == "templates" => Self::Resources {
@@ -1192,48 +1190,34 @@ mod tests {
                 }),
             ),
             // Resource command tests
-            (
-                "/resources list",
-                Command::Resources {
-                    subcommand: Some(ResourcesSubcommand::List { server_name: None }),
-                }
-            ),
-            (
-                "/resources list server1",
-                Command::Resources {
-                    subcommand: Some(ResourcesSubcommand::List { server_name: Some("server1".to_string()) }),
-                }
-            ),
-            (
-                "/resources read file://test.txt",
-                Command::Resources {
-                    subcommand: Some(ResourcesSubcommand::Read { 
-                        uri: "file://test.txt".to_string(),
-                        server_name: None 
-                    }),
-                }
-            ),
-            (
-                "/resources read file://test.txt server1",
-                Command::Resources {
-                    subcommand: Some(ResourcesSubcommand::Read { 
-                        uri: "file://test.txt".to_string(),
-                        server_name: Some("server1".to_string()) 
-                    }),
-                }
-            ),
-            (
-                "/resources templates",
-                Command::Resources {
-                    subcommand: Some(ResourcesSubcommand::Templates { server_name: None }),
-                }
-            ),
-            (
-                "/resources templates server1",
-                Command::Resources {
-                    subcommand: Some(ResourcesSubcommand::Templates { server_name: Some("server1".to_string()) }),
-                }
-            ),
+            ("/resources list", Command::Resources {
+                subcommand: Some(ResourcesSubcommand::List { server_name: None }),
+            }),
+            ("/resources list server1", Command::Resources {
+                subcommand: Some(ResourcesSubcommand::List {
+                    server_name: Some("server1".to_string()),
+                }),
+            }),
+            ("/resources read file://test.txt", Command::Resources {
+                subcommand: Some(ResourcesSubcommand::Read {
+                    uri: "file://test.txt".to_string(),
+                    server_name: None,
+                }),
+            }),
+            ("/resources read file://test.txt server1", Command::Resources {
+                subcommand: Some(ResourcesSubcommand::Read {
+                    uri: "file://test.txt".to_string(),
+                    server_name: Some("server1".to_string()),
+                }),
+            }),
+            ("/resources templates", Command::Resources {
+                subcommand: Some(ResourcesSubcommand::Templates { server_name: None }),
+            }),
+            ("/resources templates server1", Command::Resources {
+                subcommand: Some(ResourcesSubcommand::Templates {
+                    server_name: Some("server1".to_string()),
+                }),
+            }),
         ];
 
         for (input, parsed) in tests {

--- a/crates/chat-cli/src/cli/chat/mcp_resources_tests.rs
+++ b/crates/chat-cli/src/cli/chat/mcp_resources_tests.rs
@@ -1,0 +1,227 @@
+//! Integration tests for MCP resources functionality
+//! 
+//! These tests verify that the MCP resources commands work correctly
+//! and integrate properly with the chat interface.
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::chat::tool_manager::ResourceBundle;
+    use std::collections::HashMap;
+
+    /// Test that ResourceBundle can be created and contains expected fields
+    #[test]
+    fn test_resource_bundle_creation() {
+        let resource_data = serde_json::json!({
+            "uri": "file://test.txt",
+            "name": "test.txt",
+            "mimeType": "text/plain",
+            "description": "A test file"
+        });
+
+        let bundle = ResourceBundle {
+            server_name: "test_server".to_string(),
+            resource: resource_data.clone(),
+        };
+
+        assert_eq!(bundle.server_name, "test_server");
+        assert_eq!(bundle.resource.get("uri").unwrap().as_str().unwrap(), "file://test.txt");
+        assert_eq!(bundle.resource.get("name").unwrap().as_str().unwrap(), "test.txt");
+        assert_eq!(bundle.resource.get("mimeType").unwrap().as_str().unwrap(), "text/plain");
+    }
+
+    /// Test that resources cache can be populated and queried
+    #[test]
+    fn test_resources_cache_operations() {
+        let mut resources_cache = HashMap::<String, Vec<ResourceBundle>>::new();
+        
+        let resource1 = serde_json::json!({
+            "uri": "file://test1.txt",
+            "name": "test1.txt",
+            "mimeType": "text/plain"
+        });
+        
+        let resource2 = serde_json::json!({
+            "uri": "file://test2.json",
+            "name": "test2.json", 
+            "mimeType": "application/json"
+        });
+
+        let bundle1 = ResourceBundle {
+            server_name: "server1".to_string(),
+            resource: resource1,
+        };
+        
+        let bundle2 = ResourceBundle {
+            server_name: "server2".to_string(),
+            resource: resource2,
+        };
+
+        // Add resources to cache
+        resources_cache.insert("file://test1.txt".to_string(), vec![bundle1]);
+        resources_cache.insert("file://test2.json".to_string(), vec![bundle2]);
+
+        // Verify cache contents
+        assert_eq!(resources_cache.len(), 2);
+        assert!(resources_cache.contains_key("file://test1.txt"));
+        assert!(resources_cache.contains_key("file://test2.json"));
+        
+        let bundle1_ref = &resources_cache["file://test1.txt"][0];
+        assert_eq!(bundle1_ref.server_name, "server1");
+        assert_eq!(bundle1_ref.resource.get("name").unwrap().as_str().unwrap(), "test1.txt");
+    }
+
+    /// Test resource URI extraction from JSON
+    #[test]
+    fn test_resource_uri_extraction() {
+        let test_cases = vec![
+            (
+                serde_json::json!({
+                    "uri": "file://example.txt",
+                    "name": "example.txt"
+                }),
+                Some("file://example.txt")
+            ),
+            (
+                serde_json::json!({
+                    "uri": "https://example.com/api/data",
+                    "name": "API Data"
+                }),
+                Some("https://example.com/api/data")
+            ),
+            (
+                serde_json::json!({
+                    "name": "No URI resource"
+                }),
+                None
+            ),
+            (
+                serde_json::json!({
+                    "uri": null,
+                    "name": "Null URI"
+                }),
+                None
+            ),
+        ];
+
+        for (resource, expected_uri) in test_cases {
+            let extracted_uri = resource.get("uri").and_then(|u| u.as_str());
+            assert_eq!(extracted_uri, expected_uri);
+        }
+    }
+
+    /// Test resource grouping by server
+    #[test]
+    fn test_resource_grouping_by_server() {
+        let mut resources_cache = HashMap::<String, Vec<ResourceBundle>>::new();
+        
+        // Create resources from different servers
+        let resource1 = ResourceBundle {
+            server_name: "server1".to_string(),
+            resource: serde_json::json!({
+                "uri": "file://test1.txt",
+                "name": "test1.txt"
+            }),
+        };
+        
+        let resource2 = ResourceBundle {
+            server_name: "server1".to_string(),
+            resource: serde_json::json!({
+                "uri": "file://test2.txt", 
+                "name": "test2.txt"
+            }),
+        };
+        
+        let resource3 = ResourceBundle {
+            server_name: "server2".to_string(),
+            resource: serde_json::json!({
+                "uri": "file://test3.txt",
+                "name": "test3.txt"
+            }),
+        };
+
+        resources_cache.insert("file://test1.txt".to_string(), vec![resource1]);
+        resources_cache.insert("file://test2.txt".to_string(), vec![resource2]);
+        resources_cache.insert("file://test3.txt".to_string(), vec![resource3]);
+
+        // Group resources by server (simulating the logic in handle_resources_list)
+        let mut resources_by_server = HashMap::<String, Vec<(&String, &ResourceBundle)>>::new();
+        
+        for (uri, bundles) in &resources_cache {
+            for bundle in bundles {
+                resources_by_server
+                    .entry(bundle.server_name.clone())
+                    .or_insert_with(Vec::new)
+                    .push((uri, bundle));
+            }
+        }
+
+        // Verify grouping
+        assert_eq!(resources_by_server.len(), 2);
+        assert_eq!(resources_by_server["server1"].len(), 2);
+        assert_eq!(resources_by_server["server2"].len(), 1);
+    }
+
+    /// Test MIME type extraction and handling
+    #[test]
+    fn test_mime_type_handling() {
+        let test_cases = vec![
+            (
+                serde_json::json!({
+                    "uri": "file://test.txt",
+                    "mimeType": "text/plain"
+                }),
+                "text/plain"
+            ),
+            (
+                serde_json::json!({
+                    "uri": "file://test.json",
+                    "mimeType": "application/json"
+                }),
+                "application/json"
+            ),
+            (
+                serde_json::json!({
+                    "uri": "file://test.unknown"
+                }),
+                "unknown"
+            ),
+        ];
+
+        for (resource, expected_mime) in test_cases {
+            let mime_type = resource
+                .get("mimeType")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown");
+            assert_eq!(mime_type, expected_mime);
+        }
+    }
+
+    /// Test resource name fallback logic
+    #[test]
+    fn test_resource_name_fallback() {
+        let test_cases = vec![
+            (
+                serde_json::json!({
+                    "uri": "file://test.txt",
+                    "name": "Test File"
+                }),
+                "Test File"
+            ),
+            (
+                serde_json::json!({
+                    "uri": "file://no-name.txt"
+                }),
+                "file://no-name.txt"
+            ),
+        ];
+
+        for (resource, expected_name) in test_cases {
+            let uri = resource.get("uri").and_then(|u| u.as_str()).unwrap();
+            let name = resource
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(uri);
+            assert_eq!(name, expected_name);
+        }
+    }
+}

--- a/crates/chat-cli/src/cli/chat/mcp_resources_tests.rs
+++ b/crates/chat-cli/src/cli/chat/mcp_resources_tests.rs
@@ -1,12 +1,13 @@
 //! Integration tests for MCP resources functionality
-//! 
+//!
 //! These tests verify that the MCP resources commands work correctly
 //! and integrate properly with the chat interface.
 
 #[cfg(test)]
 mod tests {
-    use crate::cli::chat::tool_manager::ResourceBundle;
     use std::collections::HashMap;
+
+    use crate::cli::chat::tool_manager::ResourceBundle;
 
     /// Test that ResourceBundle can be created and contains expected fields
     #[test]
@@ -33,16 +34,16 @@ mod tests {
     #[test]
     fn test_resources_cache_operations() {
         let mut resources_cache = HashMap::<String, Vec<ResourceBundle>>::new();
-        
+
         let resource1 = serde_json::json!({
             "uri": "file://test1.txt",
             "name": "test1.txt",
             "mimeType": "text/plain"
         });
-        
+
         let resource2 = serde_json::json!({
             "uri": "file://test2.json",
-            "name": "test2.json", 
+            "name": "test2.json",
             "mimeType": "application/json"
         });
 
@@ -50,7 +51,7 @@ mod tests {
             server_name: "server1".to_string(),
             resource: resource1,
         };
-        
+
         let bundle2 = ResourceBundle {
             server_name: "server2".to_string(),
             resource: resource2,
@@ -64,7 +65,7 @@ mod tests {
         assert_eq!(resources_cache.len(), 2);
         assert!(resources_cache.contains_key("file://test1.txt"));
         assert!(resources_cache.contains_key("file://test2.json"));
-        
+
         let bundle1_ref = &resources_cache["file://test1.txt"][0];
         assert_eq!(bundle1_ref.server_name, "server1");
         assert_eq!(bundle1_ref.resource.get("name").unwrap().as_str().unwrap(), "test1.txt");
@@ -79,27 +80,27 @@ mod tests {
                     "uri": "file://example.txt",
                     "name": "example.txt"
                 }),
-                Some("file://example.txt")
+                Some("file://example.txt"),
             ),
             (
                 serde_json::json!({
                     "uri": "https://example.com/api/data",
                     "name": "API Data"
                 }),
-                Some("https://example.com/api/data")
+                Some("https://example.com/api/data"),
             ),
             (
                 serde_json::json!({
                     "name": "No URI resource"
                 }),
-                None
+                None,
             ),
             (
                 serde_json::json!({
                     "uri": null,
                     "name": "Null URI"
                 }),
-                None
+                None,
             ),
         ];
 
@@ -113,7 +114,7 @@ mod tests {
     #[test]
     fn test_resource_grouping_by_server() {
         let mut resources_cache = HashMap::<String, Vec<ResourceBundle>>::new();
-        
+
         // Create resources from different servers
         let resource1 = ResourceBundle {
             server_name: "server1".to_string(),
@@ -122,15 +123,15 @@ mod tests {
                 "name": "test1.txt"
             }),
         };
-        
+
         let resource2 = ResourceBundle {
             server_name: "server1".to_string(),
             resource: serde_json::json!({
-                "uri": "file://test2.txt", 
+                "uri": "file://test2.txt",
                 "name": "test2.txt"
             }),
         };
-        
+
         let resource3 = ResourceBundle {
             server_name: "server2".to_string(),
             resource: serde_json::json!({
@@ -145,7 +146,7 @@ mod tests {
 
         // Group resources by server (simulating the logic in handle_resources_list)
         let mut resources_by_server = HashMap::<String, Vec<(&String, &ResourceBundle)>>::new();
-        
+
         for (uri, bundles) in &resources_cache {
             for bundle in bundles {
                 resources_by_server
@@ -170,28 +171,25 @@ mod tests {
                     "uri": "file://test.txt",
                     "mimeType": "text/plain"
                 }),
-                "text/plain"
+                "text/plain",
             ),
             (
                 serde_json::json!({
                     "uri": "file://test.json",
                     "mimeType": "application/json"
                 }),
-                "application/json"
+                "application/json",
             ),
             (
                 serde_json::json!({
                     "uri": "file://test.unknown"
                 }),
-                "unknown"
+                "unknown",
             ),
         ];
 
         for (resource, expected_mime) in test_cases {
-            let mime_type = resource
-                .get("mimeType")
-                .and_then(|m| m.as_str())
-                .unwrap_or("unknown");
+            let mime_type = resource.get("mimeType").and_then(|m| m.as_str()).unwrap_or("unknown");
             assert_eq!(mime_type, expected_mime);
         }
     }
@@ -205,22 +203,19 @@ mod tests {
                     "uri": "file://test.txt",
                     "name": "Test File"
                 }),
-                "Test File"
+                "Test File",
             ),
             (
                 serde_json::json!({
                     "uri": "file://no-name.txt"
                 }),
-                "file://no-name.txt"
+                "file://no-name.txt",
             ),
         ];
 
         for (resource, expected_name) in test_cases {
             let uri = resource.get("uri").and_then(|u| u.as_str()).unwrap();
-            let name = resource
-                .get("name")
-                .and_then(|n| n.as_str())
-                .unwrap_or(uri);
+            let name = resource.get("name").and_then(|n| n.as_str()).unwrap_or(uri);
             assert_eq!(name, expected_name);
         }
     }

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -145,6 +145,27 @@ impl CustomToolClient {
         }
     }
 
+    /// Lists available resources from the MCP server
+    pub async fn list_resources(&self, cursor: Option<String>) -> Result<crate::mcp_client::facilitator_types::ResourcesListResult> {
+        match self {
+            CustomToolClient::Stdio { client, .. } => client.list_resources(cursor).await.map_err(|e| eyre::eyre!(e)),
+        }
+    }
+
+    /// Lists available resource templates from the MCP server
+    pub async fn list_resource_templates(&self, cursor: Option<String>) -> Result<crate::mcp_client::facilitator_types::ResourceTemplatesListResult> {
+        match self {
+            CustomToolClient::Stdio { client, .. } => client.list_resource_templates(cursor).await.map_err(|e| eyre::eyre!(e)),
+        }
+    }
+
+    /// Reads a resource from the MCP server
+    pub async fn read_resource(&self, uri: &str) -> Result<serde_json::Value> {
+        match self {
+            CustomToolClient::Stdio { client, .. } => client.read_resource(uri).await.map_err(|e| eyre::eyre!(e)),
+        }
+    }
+
     pub fn prompts_updated(&self) {
         match self {
             CustomToolClient::Stdio { client, .. } => client.is_prompts_out_of_date.store(false, Ordering::Relaxed),

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -146,16 +146,24 @@ impl CustomToolClient {
     }
 
     /// Lists available resources from the MCP server
-    pub async fn list_resources(&self, cursor: Option<String>) -> Result<crate::mcp_client::facilitator_types::ResourcesListResult> {
+    pub async fn list_resources(
+        &self,
+        cursor: Option<String>,
+    ) -> Result<crate::mcp_client::facilitator_types::ResourcesListResult> {
         match self {
             CustomToolClient::Stdio { client, .. } => client.list_resources(cursor).await.map_err(|e| eyre::eyre!(e)),
         }
     }
 
     /// Lists available resource templates from the MCP server
-    pub async fn list_resource_templates(&self, cursor: Option<String>) -> Result<crate::mcp_client::facilitator_types::ResourceTemplatesListResult> {
+    pub async fn list_resource_templates(
+        &self,
+        cursor: Option<String>,
+    ) -> Result<crate::mcp_client::facilitator_types::ResourceTemplatesListResult> {
         match self {
-            CustomToolClient::Stdio { client, .. } => client.list_resource_templates(cursor).await.map_err(|e| eyre::eyre!(e)),
+            CustomToolClient::Stdio { client, .. } => {
+                client.list_resource_templates(cursor).await.map_err(|e| eyre::eyre!(e))
+            },
         }
     }
 

--- a/crates/chat-cli/src/cli/chat/tools/mcp_resource.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mcp_resource.rs
@@ -1,0 +1,65 @@
+use std::io::Write;
+
+use crossterm::queue;
+use crossterm::style::{
+    self,
+    Color,
+};
+use eyre::{
+    Result,
+    bail,
+};
+use serde::{
+    Deserialize,
+};
+
+use super::{
+    InvokeOutput,
+};
+use crate::platform::Context;
+
+/// Read content from MCP resources using their URI
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpResource {
+    pub uri: String,
+    pub server_name: String,
+}
+
+impl McpResource {
+    pub async fn validate(&mut self, _ctx: &Context) -> Result<()> {
+        // Basic URI validation
+        if self.uri.is_empty() {
+            bail!("Resource URI cannot be empty");
+        }
+        
+        if self.server_name.is_empty() {
+            bail!("Server name cannot be empty");
+        }
+
+        // Note: Server validation is handled at invocation time since Context doesn't have access to tool_manager
+        
+        Ok(())
+    }
+
+    pub async fn invoke(&self, _ctx: &Context, _updates: &mut impl Write) -> Result<InvokeOutput> {
+        // This method should not be called directly for MCP resource tools
+        // The actual implementation is in ChatContext::invoke_mcp_resource_tool
+        // This is here as a fallback in case the special handling is bypassed
+        bail!("MCP resource tool should be handled by special invocation logic");
+    }
+
+    pub fn queue_description(&self, updates: &mut impl Write) -> Result<()> {
+        queue!(
+            updates,
+            style::Print("Reading MCP resource: "),
+            style::SetForegroundColor(Color::Green),
+            style::Print(&self.uri),
+            style::ResetColor,
+            style::Print(" from server "),
+            style::SetForegroundColor(Color::Cyan),
+            style::Print(&self.server_name),
+            style::ResetColor,
+        )?;
+        Ok(())
+    }
+}

--- a/crates/chat-cli/src/cli/chat/tools/mcp_resource.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mcp_resource.rs
@@ -9,13 +9,9 @@ use eyre::{
     Result,
     bail,
 };
-use serde::{
-    Deserialize,
-};
+use serde::Deserialize;
 
-use super::{
-    InvokeOutput,
-};
+use super::InvokeOutput;
 use crate::platform::Context;
 
 /// Read content from MCP resources using their URI
@@ -31,13 +27,14 @@ impl McpResource {
         if self.uri.is_empty() {
             bail!("Resource URI cannot be empty");
         }
-        
+
         if self.server_name.is_empty() {
             bail!("Server name cannot be empty");
         }
 
-        // Note: Server validation is handled at invocation time since Context doesn't have access to tool_manager
-        
+        // Note: Server validation is handled at invocation time since Context doesn't have access to
+        // tool_manager
+
         Ok(())
     }
 

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -3,6 +3,7 @@ pub mod execute;
 pub mod fs_read;
 pub mod fs_write;
 pub mod gh_issue;
+pub mod mcp_resource;
 pub mod thinking;
 pub mod use_aws;
 
@@ -20,6 +21,7 @@ use eyre::Result;
 use fs_read::FsRead;
 use fs_write::FsWrite;
 use gh_issue::GhIssue;
+use mcp_resource::McpResource;
 use serde::{
     Deserialize,
     Serialize,
@@ -41,6 +43,7 @@ pub enum Tool {
     UseAws(UseAws),
     Custom(CustomTool),
     GhIssue(GhIssue),
+    McpResource(McpResource),
     Thinking(Thinking),
 }
 
@@ -57,6 +60,7 @@ impl Tool {
             Tool::UseAws(_) => "use_aws",
             Tool::Custom(custom_tool) => &custom_tool.name,
             Tool::GhIssue(_) => "gh_issue",
+            Tool::McpResource(_) => "mcp_resource",
             Tool::Thinking(_) => "thinking (prerelease)",
         }
         .to_owned()
@@ -71,6 +75,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.requires_acceptance(),
             Tool::Custom(_) => true,
             Tool::GhIssue(_) => false,
+            Tool::McpResource(_) => true,
             Tool::Thinking(_) => false,
         }
     }
@@ -84,6 +89,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.invoke(context, updates).await,
             Tool::Custom(custom_tool) => custom_tool.invoke(context, updates).await,
             Tool::GhIssue(gh_issue) => gh_issue.invoke(updates).await,
+            Tool::McpResource(mcp_resource) => mcp_resource.invoke(context, updates).await,
             Tool::Thinking(think) => think.invoke(updates).await,
         }
     }
@@ -97,6 +103,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.queue_description(updates),
             Tool::Custom(custom_tool) => custom_tool.queue_description(updates),
             Tool::GhIssue(gh_issue) => gh_issue.queue_description(updates),
+            Tool::McpResource(mcp_resource) => mcp_resource.queue_description(updates),
             Tool::Thinking(thinking) => thinking.queue_description(updates),
         }
     }
@@ -110,6 +117,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.validate(ctx).await,
             Tool::Custom(custom_tool) => custom_tool.validate(ctx).await,
             Tool::GhIssue(gh_issue) => gh_issue.validate(ctx).await,
+            Tool::McpResource(mcp_resource) => mcp_resource.validate(ctx).await,
             Tool::Thinking(think) => think.validate(ctx).await,
         }
     }

--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -189,5 +189,23 @@
       },
       "required": ["thought"]
     }
+  },
+  "mcp_resource": {
+    "name": "mcp_resource",
+    "description": "Read content from MCP resources using their URI. This tool allows you to access and retrieve content from resources exposed by MCP servers. Use this when you need to read the actual content of a resource that was discovered via the /resources command.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "The URI of the MCP resource to read (e.g., 'echo://world', 'file:///path/to/file')"
+        },
+        "server_name": {
+          "type": "string",
+          "description": "The name of the MCP server that provides this resource"
+        }
+      },
+      "required": ["uri", "server_name"]
+    }
   }
 }

--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -576,23 +576,24 @@ where
     pub async fn list_resources(&self, cursor: Option<String>) -> Result<ResourcesListResult, ClientError> {
         let params = cursor.map(|c| serde_json::json!({"cursor": c}));
         let response = self.request("resources/list", params).await?;
-        serde_json::from_value(response.result.unwrap_or_default())
-            .map_err(ClientError::Serialization)
+        serde_json::from_value(response.result.unwrap_or_default()).map_err(ClientError::Serialization)
     }
 
     /// Lists available resource templates from the MCP server
-    pub async fn list_resource_templates(&self, cursor: Option<String>) -> Result<ResourceTemplatesListResult, ClientError> {
+    pub async fn list_resource_templates(
+        &self,
+        cursor: Option<String>,
+    ) -> Result<ResourceTemplatesListResult, ClientError> {
         let params = cursor.map(|c| serde_json::json!({"cursor": c}));
         let response = self.request("resources/templates/list", params).await?;
-        serde_json::from_value(response.result.unwrap_or_default())
-            .map_err(ClientError::Serialization)
+        serde_json::from_value(response.result.unwrap_or_default()).map_err(ClientError::Serialization)
     }
 
     /// Reads content from a specific resource URI
     pub async fn read_resource(&self, uri: &str) -> Result<serde_json::Value, ClientError> {
         let params = serde_json::json!({"uri": uri});
         let response = self.request("resources/read", Some(params)).await?;
-        
+
         // Check if there's an error in the response
         if let Some(error) = response.error {
             return Err(ClientError::JsonRpc {
@@ -601,7 +602,7 @@ where
                 data: error.data,
             });
         }
-        
+
         // Return the result or default if no error
         Ok(response.result.unwrap_or_default())
     }


### PR DESCRIPTION
Implement MCP resources support for listing, reading, and using resource (dynamic) templates

See MCP spec: https://modelcontextprotocol.io/docs/concepts/resources


*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/1462

*Description of changes:*
- Add ResourceBundle for caching resource information
- Implement MCP resource methods in CustomToolClient
- Connect resource command handlers to MCP client methods
- Add resource listing with server grouping and URI display
- Implement resource content reading with proper format handling
- Add resource templates listing functionality
- Update tool index with MCP resource definitions

NOTE: Only text and application/json MIME types are officially supported with this change. Further changes are required to support other MIME types/doc formats.

https://github.com/user-attachments/assets/0806942a-f76d-4e8c-a243-d4729df80bfd


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
