### PR TITLE
fix: update fs_write tool for relative and absolute paths

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -3,17 +3,36 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use crossterm::queue;
-use crossterm::style::{self, Color};
-use eyre::{ContextCompat as _, Result, bail, eyre};
+use crossterm::style::{
+    self,
+    Color,
+};
+use eyre::{
+    ContextCompat as _,
+    Result,
+    bail,
+    eyre,
+};
 use serde::Deserialize;
 use similar::DiffableStr;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
-use syntect::util::{LinesWithEndings, as_24_bit_terminal_escaped};
-use tracing::{error, warn};
+use syntect::util::{
+    LinesWithEndings,
+    as_24_bit_terminal_escaped,
+};
+use tracing::{
+    error,
+    warn,
+};
 
-use super::{InvokeOutput, format_path, sanitize_path_tool_arg, supports_truecolor};
+use super::{
+    InvokeOutput,
+    format_path,
+    sanitize_path_tool_arg,
+    supports_truecolor,
+};
 use crate::platform::Context;
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -3,36 +3,17 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use crossterm::queue;
-use crossterm::style::{
-    self,
-    Color,
-};
-use eyre::{
-    ContextCompat as _,
-    Result,
-    bail,
-    eyre,
-};
+use crossterm::style::{self, Color};
+use eyre::{ContextCompat as _, Result, bail, eyre};
 use serde::Deserialize;
 use similar::DiffableStr;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
-use syntect::util::{
-    LinesWithEndings,
-    as_24_bit_terminal_escaped,
-};
-use tracing::{
-    error,
-    warn,
-};
+use syntect::util::{LinesWithEndings, as_24_bit_terminal_escaped};
+use tracing::{error, warn};
 
-use super::{
-    InvokeOutput,
-    format_path,
-    sanitize_path_tool_arg,
-    supports_truecolor,
-};
+use super::{InvokeOutput, format_path, sanitize_path_tool_arg, supports_truecolor};
 use crate::platform::Context;
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
@@ -169,10 +150,11 @@ impl FsWrite {
         match self {
             FsWrite::Create { path, .. } => {
                 let file_text = self.canonical_create_command_text();
-                let relative_path = format_path(cwd, path);
-                let prev = if ctx.fs().exists(path) {
-                    let file = ctx.fs().read_to_string_sync(path)?;
-                    stylize_output_if_able(ctx, path, &file)
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let prev = if ctx.fs().exists(&path) {
+                    let file = ctx.fs().read_to_string_sync(&path)?;
+                    stylize_output_if_able(ctx, &path, &file)
                 } else {
                     Default::default()
                 };
@@ -185,8 +167,9 @@ impl FsWrite {
                 insert_line,
                 new_str,
             } => {
-                let relative_path = format_path(cwd, path);
-                let file = ctx.fs().read_to_string_sync(&relative_path)?;
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let file = ctx.fs().read_to_string_sync(&path)?;
 
                 // Diff the old with the new by adding extra context around the line being inserted
                 // at.
@@ -204,8 +187,9 @@ impl FsWrite {
                 Ok(())
             },
             FsWrite::StrReplace { path, old_str, new_str } => {
-                let relative_path = format_path(cwd, path);
-                let file = ctx.fs().read_to_string_sync(&relative_path)?;
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let file = ctx.fs().read_to_string_sync(&path)?;
                 let (start_line, _) = match line_number_at(&file, old_str) {
                     Some((start_line, end_line)) => (start_line, end_line),
                     _ => (0, 0),
@@ -217,8 +201,9 @@ impl FsWrite {
                 Ok(())
             },
             FsWrite::Append { path, new_str } => {
-                let relative_path = format_path(cwd, path);
-                let start_line = ctx.fs().read_to_string_sync(&relative_path)?.lines().count() + 1;
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let start_line = ctx.fs().read_to_string_sync(&path)?.lines().count() + 1;
                 let file = stylize_output_if_able(ctx, &relative_path, new_str);
                 print_diff(updates, &Default::default(), &file, start_line)?;
                 Ok(())
@@ -260,7 +245,9 @@ impl FsWrite {
             FsWrite::Insert { path, .. } => path,
             FsWrite::Append { path, .. } => path,
         };
-        let relative_path = format_path(cwd, path);
+        // Sanitize the path to handle tilde expansion
+        let path = sanitize_path_tool_arg(ctx, path);
+        let relative_path = format_path(cwd, &path);
         queue!(
             updates,
             style::Print("Path: "),
@@ -294,11 +281,23 @@ impl FsWrite {
 
 /// Writes `content` to `path`, adding a newline if necessary.
 async fn write_to_file(ctx: &Context, path: impl AsRef<Path>, mut content: String) -> Result<()> {
+    let path_ref = path.as_ref();
+
+    // Log the path being written to
+    tracing::debug!("Writing to file: {:?}", path_ref);
+
     if !content.ends_with_newline() {
         content.push('\n');
     }
-    ctx.fs().write(path.as_ref(), content).await?;
-    Ok(())
+
+    // Try to write the file and provide better error context
+    match ctx.fs().write(path_ref, content).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            tracing::error!("Failed to write to file {:?}: {}", path_ref, e);
+            Err(eyre::eyre!("Failed to write to file {:?}: {}", path_ref, e))
+        },
+    }
 }
 
 /// Returns a prefix/suffix pair before and after the content dictated by `[start_line, end_line]`
@@ -950,4 +949,74 @@ mod tests {
         assert_eq!(terminal_width_required_for_line_count(100), 3);
         assert_eq!(terminal_width_required_for_line_count(999), 3);
     }
+}
+#[tokio::test]
+async fn test_fs_write_with_tilde_paths() {
+    // Create a test context
+    let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+    let mut stdout = std::io::stdout();
+
+    // Get the home directory from the context
+    let home_dir = ctx.env().home().unwrap_or_default();
+    println!("Test home directory: {:?}", home_dir);
+
+    // Create a file directly in the home directory first to ensure it exists
+    let home_path = ctx.fs().chroot_path(&home_dir);
+    println!("Chrooted home path: {:?}", home_path);
+
+    // Ensure the home directory exists
+    ctx.fs().create_dir_all(&home_path).await.unwrap();
+
+    let v = serde_json::json!({
+        "path": "~/file.txt",
+        "command": "create",
+        "file_text": "content in home file"
+    });
+
+    let result = serde_json::from_value::<FsWrite>(v)
+        .unwrap()
+        .invoke(&ctx, &mut stdout)
+        .await;
+
+    match &result {
+        Ok(_) => println!("Writing to ~/file.txt succeeded"),
+        Err(e) => println!("Writing to ~/file.txt failed: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Writing to ~/file.txt should succeed");
+
+    // Verify content was written correctly
+    let file_path = home_path.join("file.txt");
+    println!("Checking file at: {:?}", file_path);
+
+    let content_result = ctx.fs().read_to_string(&file_path).await;
+    match &content_result {
+        Ok(content) => println!("Read content: {:?}", content),
+        Err(e) => println!("Failed to read content: {:?}", e),
+    }
+
+    assert!(content_result.is_ok(), "Should be able to read from expanded path");
+    assert_eq!(content_result.unwrap(), "content in home file\n");
+
+    // Test with "~/nested/path/file.txt" to ensure deep paths work
+    let nested_dir = home_path.join("nested").join("path");
+    ctx.fs().create_dir_all(&nested_dir).await.unwrap();
+
+    let v = serde_json::json!({
+        "path": "~/nested/path/file.txt",
+        "command": "create",
+        "file_text": "content in nested path"
+    });
+
+    let result = serde_json::from_value::<FsWrite>(v)
+        .unwrap()
+        .invoke(&ctx, &mut stdout)
+        .await;
+
+    assert!(result.is_ok(), "Writing to ~/nested/path/file.txt should succeed");
+
+    // Verify nested path content
+    let nested_file_path = nested_dir.join("file.txt");
+    let nested_content = ctx.fs().read_to_string(&nested_file_path).await.unwrap();
+    assert_eq!(nested_content, "content in nested path\n");
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/1932

*Description of changes:*
- Handles bug where `~` in path would cause fs_write issue:
```

Amazon Q is having trouble responding right now:
   0: failed to print tool, `fs_write`: No such file or directory (os error 2)

Location:
   crates/chat-cli/src/cli/chat/mod.rs:1221

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```
Before:
<img width="836" alt="Screenshot 2025-06-17 at 8 27 34 AM" src="https://github.com/user-attachments/assets/30acd191-0866-42dc-b8c1-7353040714a7" />

After:
<img width="836" alt="Screenshot 2025-06-17 at 8 26 39 AM" src="https://github.com/user-attachments/assets/d94caf29-9503-46e7-8369-c62abe1c3b9f" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
