### PR TITLE
Fix/mcp disable

### DIFF
--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -287,7 +287,22 @@ impl ToolManagerBuilder {
         let regex = regex::Regex::new(VALID_TOOL_NAME)?;
         let mut hasher = DefaultHasher::new();
         let is_interactive = self.is_interactive;
-        let pre_initialized = mcp_servers
+        
+        // Separate enabled and disabled servers
+        let (enabled_servers, disabled_servers): (Vec<_>, Vec<_>) = mcp_servers
+            .into_iter()
+            .partition(|(_, server_config)| !server_config.disabled);
+        
+        // Prepare disabled servers for display
+        let disabled_servers_display: Vec<String> = disabled_servers
+            .iter()
+            .map(|(server_name, _)| {
+                let snaked_cased_name = server_name.to_case(convert_case::Case::Snake);
+                sanitize_name(snaked_cased_name, &regex, &mut hasher)
+            })
+            .collect();
+        
+        let pre_initialized = enabled_servers
             .into_iter()
             .map(|(server_name, server_config)| {
                 let snaked_cased_name = server_name.to_case(convert_case::Case::Snake);
@@ -296,6 +311,7 @@ impl ToolManagerBuilder {
                 (sanitized_server_name, custom_tool_client)
             })
             .collect::<Vec<(String, _)>>();
+        
         let mut loading_servers = HashMap::<String, Instant>::new();
         for (server_name, _) in &pre_initialized {
             let init_time = std::time::Instant::now();
@@ -306,14 +322,24 @@ impl ToolManagerBuilder {
         // Spawn a task for displaying the mcp loading statuses.
         // This is only necessary when we are in interactive mode AND there are servers to load.
         // Otherwise we do not need to be spawning this.
-        let (_loading_display_task, loading_status_sender) = if is_interactive && total > 0 {
+        let (_loading_display_task, loading_status_sender) = if is_interactive && (total > 0 || !disabled_servers_display.is_empty()) {
             let (tx, mut rx) = tokio::sync::mpsc::channel::<LoadingMsg>(50);
+            let disabled_servers_display_clone = disabled_servers_display.clone();
             (
                 Some(tokio::task::spawn(async move {
                     let mut spinner_logo_idx: usize = 0;
                     let mut complete: usize = 0;
                     let mut failed: usize = 0;
-                    queue_init_message(spinner_logo_idx, complete, failed, total, &mut output)?;
+                    
+                    // Show disabled servers immediately
+                    for server_name in &disabled_servers_display_clone {
+                        queue_disabled_message(server_name, &mut output)?;
+                    }
+                    
+                    if total > 0 {
+                        queue_init_message(spinner_logo_idx, complete, failed, total, &mut output)?;
+                    }
+                    
                     loop {
                         match tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
                             Ok(Some(recv_result)) => match recv_result {
@@ -352,7 +378,7 @@ impl ToolManagerBuilder {
                                     queue_init_message(spinner_logo_idx, complete, failed, total, &mut output)?;
                                 },
                                 LoadingMsg::Terminate { still_loading } => {
-                                    if !still_loading.is_empty() {
+                                    if !still_loading.is_empty() && total > 0 {
                                         execute!(
                                             output,
                                             cursor::MoveToColumn(0),
@@ -365,6 +391,14 @@ impl ToolManagerBuilder {
                                         });
                                         let msg = eyre::eyre!(msg);
                                         queue_incomplete_load_message(complete, total, &msg, &mut output)?;
+                                    } else if total > 0 {
+                                        // Clear the loading line if we have enabled servers
+                                        execute!(
+                                            output,
+                                            cursor::MoveToColumn(0),
+                                            cursor::MoveUp(1),
+                                            terminal::Clear(terminal::ClearType::CurrentLine),
+                                        )?;
                                     }
                                     execute!(output, style::Print("\n"),)?;
                                     break;
@@ -687,6 +721,7 @@ impl ToolManagerBuilder {
             has_new_stuff,
             is_interactive,
             mcp_load_record: load_record,
+            disabled_servers: disabled_servers_display,
             ..Default::default()
         })
     }
@@ -776,6 +811,9 @@ pub struct ToolManager {
     /// invalid characters).
     /// The value is the load message (i.e. load time, warnings, and errors)
     pub mcp_load_record: Arc<Mutex<HashMap<String, Vec<LoadingRecord>>>>,
+
+    /// List of disabled MCP server names for display purposes
+    disabled_servers: Vec<String>,
 }
 
 impl Clone for ToolManager {
@@ -790,6 +828,7 @@ impl Clone for ToolManager {
             schema: self.schema.clone(),
             is_interactive: self.is_interactive,
             mcp_load_record: self.mcp_load_record.clone(),
+            disabled_servers: self.disabled_servers.clone(),
             ..Default::default()
         }
     }
@@ -1469,6 +1508,19 @@ fn queue_warn_message(name: &str, msg: &eyre::Report, time: &str, output: &mut i
         style::ResetColor,
         style::Print(" with the following warning:\n"),
         style::Print(msg),
+        style::ResetColor,
+    )?)
+}
+
+fn queue_disabled_message(name: &str, output: &mut impl Write) -> eyre::Result<()> {
+    Ok(queue!(
+        output,
+        style::SetForegroundColor(style::Color::DarkGrey),
+        style::Print("○ "),
+        style::SetForegroundColor(style::Color::Blue),
+        style::Print(name),
+        style::ResetColor,
+        style::Print(" is disabled\n"),
         style::ResetColor,
     )?)
 }

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -42,6 +42,8 @@ pub struct CustomToolConfig {
     pub env: Option<HashMap<String, String>>,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    #[serde(default)]
+    pub disabled: bool,
 }
 
 pub fn default_timeout() -> u64 {
@@ -65,6 +67,7 @@ impl CustomToolClient {
             args,
             env,
             timeout,
+            disabled: _,
         } = config;
         let mcp_client_config = McpClientConfig {
             server_name: server_name.clone(),

--- a/crates/chat-cli/src/cli/mcp.rs
+++ b/crates/chat-cli/src/cli/mcp.rs
@@ -94,6 +94,9 @@ pub struct AddArgs {
     /// Server launch timeout, in milliseconds
     #[arg(long)]
     pub timeout: Option<u64>,
+    /// Whether the server should be disabled (not loaded)
+    #[arg(long, default_value_t = false)]
+    pub disabled: bool,
     /// Overwrite an existing server with the same name
     #[arg(long, default_value_t = false)]
     pub force: bool,
@@ -120,6 +123,7 @@ impl AddArgs {
             "command": self.command,
             "env": merged_env,
             "timeout": self.timeout.unwrap_or(default_timeout()),
+            "disabled": self.disabled,
         }))?;
 
         writeln!(
@@ -203,7 +207,8 @@ impl ListArgs {
             match cfg_opt {
                 Some(cfg) if !cfg.mcp_servers.is_empty() => {
                     for (name, tool_cfg) in &cfg.mcp_servers {
-                        writeln!(output, "    • {name:<12} {}", tool_cfg.command)?;
+                        let status = if tool_cfg.disabled { " (disabled)" } else { "" };
+                        writeln!(output, "    • {name:<12} {}{}", tool_cfg.command, status)?;
                     }
                 },
                 _ => {
@@ -287,6 +292,7 @@ impl StatusArgs {
                     style::Print(format!("File    : {}\n", path.display())),
                     style::Print(format!("Command : {}\n", cfg.command)),
                     style::Print(format!("Timeout : {} ms\n", cfg.timeout)),
+                    style::Print(format!("Disabled: {}\n", cfg.disabled)),
                     style::Print(format!(
                         "Env Vars: {}\n",
                         cfg.env
@@ -451,6 +457,7 @@ mod tests {
             env: vec![],
             timeout: None,
             scope: None,
+            disabled: false,
             force: false,
         }
         .execute(&ctx, &mut out)
@@ -501,6 +508,7 @@ mod tests {
                     .collect()
                 ],
                 timeout: None,
+                disabled: false,
                 force: false,
             }))
         );


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Fixes issue where if an MCP server configuration has disabled as true, the server would still be loaded. This prevents loading and shows disabled servers when starting up.



<img width="822" alt="Screenshot 2025-06-17 at 9 49 23 AM" src="https://github.com/user-attachments/assets/d30e1dcb-b712-4253-be1f-a83475cd06cf" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

