### PR TITLE
fix: Add support for passing "args" to MCP configuration when using `q mcp add`

### DIFF
--- a/.amazonq/mcp.json
+++ b/.amazonq/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "awslabs.eks-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "awslabs.eks-mcp-server",
+        "--allow-write",
+        "--allow-sensitive-data-access"
+      ],
+      "env": {},
+      "timeout": 120000
+    }
+  }
+}

--- a/crates/chat-cli/src/cli/mcp.rs
+++ b/crates/chat-cli/src/cli/mcp.rs
@@ -85,6 +85,9 @@ pub struct AddArgs {
     /// The command used to launch the server
     #[arg(long)]
     pub command: String,
+    /// Arguments to pass to the command
+    #[arg(long, value_delimiter = ',')]
+    pub args: Vec<String>,
     /// Where to add the server to.
     #[arg(long, value_enum)]
     pub scope: Option<Scope>,
@@ -118,6 +121,7 @@ impl AddArgs {
         let merged_env = self.env.into_iter().flatten().collect::<HashMap<_, _>>();
         let tool: CustomToolConfig = serde_json::from_value(serde_json::json!({
             "command": self.command,
+            "args": self.args,
             "env": merged_env,
             "timeout": self.timeout.unwrap_or(default_timeout()),
         }))?;
@@ -448,6 +452,11 @@ mod tests {
         AddArgs {
             name: "local".into(),
             command: "echo hi".into(),
+            args: vec![
+                "awslabs.eks-mcp-server".to_string(),
+                "--allow-write".to_string(),
+                "--allow-sensitive-data-access".to_string(),
+            ],
             env: vec![],
             timeout: None,
             scope: None,
@@ -491,6 +500,11 @@ mod tests {
             RootSubcommand::Mcp(McpSubcommand::Add(AddArgs {
                 name: "test_server".to_string(),
                 command: "test_command".to_string(),
+                args: vec![
+                "awslabs.eks-mcp-server".to_string(),
+                "--allow-write".to_string(),
+                "--allow-sensitive-data-access".to_string(),
+            ],
                 scope: None,
                 env: vec![
                     [

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -369,7 +369,7 @@ impl Cli {
                 },
                 CliRootCommands::Mcp { args } => {
                     if args.iter().any(|arg| ["--help", "-h"].contains(&arg.as_str())) {
-                        return Self::execute_chat("mcp", Some(vec!["--help".to_owned()]), false).await;
+                        return Self::execute_chat("mcp", Some(args), false).await;
                     }
 
                     Self::execute_chat("mcp", Some(args), true).await


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/2025

*Description of changes:*
Adds `--args` flag support to the q mcp add command, allowing proper separation of command and arguments in MCP server configurations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
