### PR TITLE
Fix/fs read

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3578,7 +3578,7 @@ impl ChatContext {
                         style::SetAttribute(Attribute::Bold),
                         style::Print(format!(" ● Completed in {}s", tool_time)),
                         style::SetForegroundColor(Color::Reset),
-                        style::Print("\n"),
+                        style::Print("\n\n"),
                     )?;
 
                     tool_telemetry = tool_telemetry.and_modify(|ev| ev.is_success = Some(true));

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -6,6 +6,7 @@ use crossterm::queue;
 use crossterm::style::{
     self,
     Color,
+    Stylize,
 };
 use eyre::{
     Result,
@@ -28,12 +29,16 @@ use super::{
     format_path,
     sanitize_path_tool_arg,
 };
+use crate::cli::chat::CONTINUATION_LINE;
 use crate::cli::chat::util::images::{
     handle_images_from_paths,
     is_supported_image_type,
     pre_process,
 };
 use crate::platform::Context;
+
+const CHECKMARK: &str = "✔";
+const CROSS: &str = "✘";
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "mode")]
@@ -145,7 +150,9 @@ impl FsLine {
 
     pub async fn queue_description(&self, ctx: &Context, updates: &mut impl Write) -> Result<()> {
         let path = sanitize_path_tool_arg(ctx, &self.path);
-        let line_count = ctx.fs().read_to_string(&path).await?.lines().count();
+        let file_bytes = ctx.fs().read(&path).await?;
+        let file_content = String::from_utf8_lossy(&file_bytes);
+        let line_count = file_content.lines().count();
         queue!(
             updates,
             style::Print("Reading file: "),
@@ -184,8 +191,9 @@ impl FsLine {
     pub async fn invoke(&self, ctx: &Context, _updates: &mut impl Write) -> Result<InvokeOutput> {
         let path = sanitize_path_tool_arg(ctx, &self.path);
         debug!(?path, "Reading");
-        let file = ctx.fs().read_to_string(&path).await?;
-        let line_count = file.lines().count();
+        let file_bytes = ctx.fs().read(&path).await?;
+        let file_content = String::from_utf8_lossy(&file_bytes);
+        let line_count = file_content.lines().count();
         let (start, end) = (
             convert_negative_index(line_count, self.start_line()),
             convert_negative_index(line_count, self.end_line()),
@@ -204,7 +212,7 @@ impl FsLine {
         }
 
         // The range should be inclusive on both ends.
-        let file_contents = file
+        let file_contents = file_content
             .lines()
             .skip(start)
             .take(end - start + 1)
@@ -272,6 +280,7 @@ impl FsSearch {
             style::SetForegroundColor(Color::Green),
             style::Print(&self.pattern.to_lowercase()),
             style::ResetColor,
+            style::Print("\n"),
         )?;
         Ok(())
     }
@@ -279,9 +288,9 @@ impl FsSearch {
     pub async fn invoke(&self, ctx: &Context, updates: &mut impl Write) -> Result<InvokeOutput> {
         let file_path = sanitize_path_tool_arg(ctx, &self.path);
         let pattern = &self.pattern;
-        let relative_path = format_path(ctx.env().current_dir()?, &file_path);
 
-        let file_content = ctx.fs().read_to_string(&file_path).await?;
+        let file_bytes = ctx.fs().read(&file_path).await?;
+        let file_content = String::from_utf8_lossy(&file_bytes);
         let lines: Vec<&str> = LinesWithEndings::from(&file_content).collect();
 
         let mut results = Vec::new();
@@ -311,16 +320,35 @@ impl FsSearch {
                 });
             }
         }
+        let match_text = if total_matches == 1 {
+            "1 match".to_string()
+        } else {
+            format!("{} matches", total_matches)
+        };
+
+        let color = if total_matches == 0 {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
+
+        let result = if total_matches == 0 {
+            CROSS.yellow()
+        } else {
+            CHECKMARK.green()
+        };
 
         queue!(
             updates,
             style::SetForegroundColor(Color::Yellow),
             style::ResetColor,
-            style::Print(format!(
-                "Found {} matches for pattern '{}' in {}\n",
-                total_matches, pattern, relative_path
-            )),
+            style::Print(CONTINUATION_LINE),
             style::Print("\n"),
+            style::Print(" "),
+            style::Print(result),
+            style::Print(" Found: "),
+            style::SetForegroundColor(color),
+            style::Print(match_text),
             style::ResetColor,
         )?;
 
@@ -740,5 +768,251 @@ mod tests {
                 FsSearch::CONTEXT_LINE_PREFIX
             )
         );
+    }
+
+    #[tokio::test]
+    async fn test_fs_read_non_utf8_binary_file() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let fs = ctx.fs();
+        let mut stdout = std::io::stdout();
+
+        let binary_data = vec![0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8];
+        let binary_file_path = "/binary_test.dat";
+        fs.write(binary_file_path, &binary_data).await.unwrap();
+
+        let v = serde_json::json!({
+            "path": binary_file_path,
+            "mode": "Line"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(text) = output.output {
+            assert!(text.contains('�'), "Binary data should contain replacement characters");
+            assert_eq!(text.chars().count(), 8, "Should have 8 replacement characters");
+            assert!(
+                text.chars().all(|c| c == '�'),
+                "All characters should be replacement characters"
+            );
+        } else {
+            panic!("expected text output");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fs_read_latin1_encoded_file() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let fs = ctx.fs();
+        let mut stdout = std::io::stdout();
+
+        let latin1_data = vec![99, 97, 102, 233]; // "café" in Latin-1
+        let latin1_file_path = "/latin1_test.txt";
+        fs.write(latin1_file_path, &latin1_data).await.unwrap();
+
+        let v = serde_json::json!({
+            "path": latin1_file_path,
+            "mode": "Line"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(text) = output.output {
+            // Latin-1 byte 233 (é) is invalid UTF-8, so it becomes a replacement character
+            assert!(text.starts_with("caf"), "Should start with 'caf'");
+            assert!(
+                text.contains('�'),
+                "Should contain replacement character for invalid UTF-8"
+            );
+        } else {
+            panic!("expected text output");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fs_search_non_utf8_file() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let fs = ctx.fs();
+        let mut stdout = std::io::stdout();
+
+        let mut mixed_data = Vec::new();
+        mixed_data.extend_from_slice(b"Hello world\n");
+        mixed_data.extend_from_slice(&[0xff, 0xfe]); // Invalid UTF-8 bytes
+        mixed_data.extend_from_slice(b"\nGoodbye world\n");
+
+        let mixed_file_path = "/mixed_encoding_test.txt";
+        fs.write(mixed_file_path, &mixed_data).await.unwrap();
+
+        let v = serde_json::json!({
+            "mode": "Search",
+            "path": mixed_file_path,
+            "pattern": "hello"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(value) = output.output {
+            let matches: Vec<SearchMatch> = serde_json::from_str(&value).unwrap();
+            assert_eq!(matches.len(), 1, "Should find one match for 'hello'");
+            assert_eq!(matches[0].line_number, 1, "Match should be on line 1");
+            assert!(
+                matches[0].context.contains("Hello world"),
+                "Should contain the matched line"
+            );
+        } else {
+            panic!("expected Text output");
+        }
+
+        let v = serde_json::json!({
+            "mode": "Search",
+            "path": mixed_file_path,
+            "pattern": "goodbye"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(value) = output.output {
+            let matches: Vec<SearchMatch> = serde_json::from_str(&value).unwrap();
+            assert_eq!(matches.len(), 1, "Should find one match for 'goodbye'");
+            assert!(
+                matches[0].context.contains("Goodbye world"),
+                "Should contain the matched line"
+            );
+        } else {
+            panic!("expected Text output");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fs_read_windows1252_encoded_file() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let fs = ctx.fs();
+        let mut stdout = std::io::stdout();
+
+        let mut windows1252_data = Vec::new();
+        windows1252_data.extend_from_slice(b"Text with ");
+        windows1252_data.push(0x93); // Left double quotation mark in Windows-1252
+        windows1252_data.extend_from_slice(b"smart quotes");
+        windows1252_data.push(0x94); // Right double quotation mark in Windows-1252
+
+        let windows1252_file_path = "/windows1252_test.txt";
+        fs.write(windows1252_file_path, &windows1252_data).await.unwrap();
+
+        let v = serde_json::json!({
+            "path": windows1252_file_path,
+            "mode": "Line"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(text) = output.output {
+            assert!(text.contains("Text with"), "Should contain readable text");
+            assert!(text.contains("smart quotes"), "Should contain readable text");
+            assert!(
+                text.contains('�'),
+                "Should contain replacement characters for invalid UTF-8"
+            );
+        } else {
+            panic!("expected text output");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fs_search_pattern_with_replacement_chars() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let fs = ctx.fs();
+        let mut stdout = std::io::stdout();
+
+        let mut data_with_invalid_utf8 = Vec::new();
+        data_with_invalid_utf8.extend_from_slice(b"Line 1: caf");
+        data_with_invalid_utf8.push(0xe9); // Invalid UTF-8 byte (Latin-1 é)
+        data_with_invalid_utf8.extend_from_slice(b"\nLine 2: hello world\n");
+
+        let invalid_utf8_file_path = "/invalid_utf8_search_test.txt";
+        fs.write(invalid_utf8_file_path, &data_with_invalid_utf8).await.unwrap();
+
+        let v = serde_json::json!({
+            "mode": "Search",
+            "path": invalid_utf8_file_path,
+            "pattern": "caf"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(value) = output.output {
+            let matches: Vec<SearchMatch> = serde_json::from_str(&value).unwrap();
+            assert_eq!(matches.len(), 1, "Should find one match for 'caf'");
+            assert_eq!(matches[0].line_number, 1, "Match should be on line 1");
+            assert!(matches[0].context.contains("caf"), "Should contain 'caf'");
+        } else {
+            panic!("expected Text output");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fs_read_empty_file_with_invalid_utf8() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let fs = ctx.fs();
+        let mut stdout = std::io::stdout();
+
+        let invalid_only_data = vec![0xff, 0xfe, 0xfd];
+        let invalid_only_file_path = "/invalid_only_test.txt";
+        fs.write(invalid_only_file_path, &invalid_only_data).await.unwrap();
+
+        let v = serde_json::json!({
+            "path": invalid_only_file_path,
+            "mode": "Line"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(text) = output.output {
+            assert_eq!(text.chars().count(), 3, "Should have 3 replacement characters");
+            assert!(text.chars().all(|c| c == '�'), "Should be all replacement characters");
+        } else {
+            panic!("expected text output");
+        }
+
+        let v = serde_json::json!({
+            "mode": "Search",
+            "path": invalid_only_file_path,
+            "pattern": "test"
+        });
+        let output = serde_json::from_value::<FsRead>(v)
+            .unwrap()
+            .invoke(&ctx, &mut stdout)
+            .await
+            .unwrap();
+
+        if let OutputKind::Text(value) = output.output {
+            let matches: Vec<SearchMatch> = serde_json::from_str(&value).unwrap();
+            assert_eq!(
+                matches.len(),
+                0,
+                "Should find no matches in file with only invalid UTF-8"
+            );
+        } else {
+            panic!("expected Text output");
+        }
     }
 }

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -3,17 +3,36 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use crossterm::queue;
-use crossterm::style::{self, Color};
-use eyre::{ContextCompat as _, Result, bail, eyre};
+use crossterm::style::{
+    self,
+    Color,
+};
+use eyre::{
+    ContextCompat as _,
+    Result,
+    bail,
+    eyre,
+};
 use serde::Deserialize;
 use similar::DiffableStr;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
-use syntect::util::{LinesWithEndings, as_24_bit_terminal_escaped};
-use tracing::{error, warn};
+use syntect::util::{
+    LinesWithEndings,
+    as_24_bit_terminal_escaped,
+};
+use tracing::{
+    error,
+    warn,
+};
 
-use super::{InvokeOutput, format_path, sanitize_path_tool_arg, supports_truecolor};
+use super::{
+    InvokeOutput,
+    format_path,
+    sanitize_path_tool_arg,
+    supports_truecolor,
+};
 use crate::platform::Context;
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -3,36 +3,17 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use crossterm::queue;
-use crossterm::style::{
-    self,
-    Color,
-};
-use eyre::{
-    ContextCompat as _,
-    Result,
-    bail,
-    eyre,
-};
+use crossterm::style::{self, Color};
+use eyre::{ContextCompat as _, Result, bail, eyre};
 use serde::Deserialize;
 use similar::DiffableStr;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
-use syntect::util::{
-    LinesWithEndings,
-    as_24_bit_terminal_escaped,
-};
-use tracing::{
-    error,
-    warn,
-};
+use syntect::util::{LinesWithEndings, as_24_bit_terminal_escaped};
+use tracing::{error, warn};
 
-use super::{
-    InvokeOutput,
-    format_path,
-    sanitize_path_tool_arg,
-    supports_truecolor,
-};
+use super::{InvokeOutput, format_path, sanitize_path_tool_arg, supports_truecolor};
 use crate::platform::Context;
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
@@ -169,10 +150,11 @@ impl FsWrite {
         match self {
             FsWrite::Create { path, .. } => {
                 let file_text = self.canonical_create_command_text();
-                let relative_path = format_path(cwd, path);
-                let prev = if ctx.fs().exists(path) {
-                    let file = ctx.fs().read_to_string_sync(path)?;
-                    stylize_output_if_able(ctx, path, &file)
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let prev = if ctx.fs().exists(&path) {
+                    let file = ctx.fs().read_to_string_sync(&path)?;
+                    stylize_output_if_able(ctx, &path, &file)
                 } else {
                     Default::default()
                 };
@@ -185,8 +167,9 @@ impl FsWrite {
                 insert_line,
                 new_str,
             } => {
-                let relative_path = format_path(cwd, path);
-                let file = ctx.fs().read_to_string_sync(&relative_path)?;
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let file = ctx.fs().read_to_string_sync(&path)?;
 
                 // Diff the old with the new by adding extra context around the line being inserted
                 // at.
@@ -204,8 +187,9 @@ impl FsWrite {
                 Ok(())
             },
             FsWrite::StrReplace { path, old_str, new_str } => {
-                let relative_path = format_path(cwd, path);
-                let file = ctx.fs().read_to_string_sync(&relative_path)?;
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let file = ctx.fs().read_to_string_sync(&path)?;
                 let (start_line, _) = match line_number_at(&file, old_str) {
                     Some((start_line, end_line)) => (start_line, end_line),
                     _ => (0, 0),
@@ -217,8 +201,9 @@ impl FsWrite {
                 Ok(())
             },
             FsWrite::Append { path, new_str } => {
-                let relative_path = format_path(cwd, path);
-                let start_line = ctx.fs().read_to_string_sync(&relative_path)?.lines().count() + 1;
+                let path = sanitize_path_tool_arg(ctx, path);
+                let relative_path = format_path(cwd, &path);
+                let start_line = ctx.fs().read_to_string_sync(&path)?.lines().count() + 1;
                 let file = stylize_output_if_able(ctx, &relative_path, new_str);
                 print_diff(updates, &Default::default(), &file, start_line)?;
                 Ok(())
@@ -260,7 +245,9 @@ impl FsWrite {
             FsWrite::Insert { path, .. } => path,
             FsWrite::Append { path, .. } => path,
         };
-        let relative_path = format_path(cwd, path);
+        // Sanitize the path to handle tilde expansion
+        let path = sanitize_path_tool_arg(ctx, path);
+        let relative_path = format_path(cwd, &path);
         queue!(
             updates,
             style::Print("Path: "),
@@ -294,11 +281,23 @@ impl FsWrite {
 
 /// Writes `content` to `path`, adding a newline if necessary.
 async fn write_to_file(ctx: &Context, path: impl AsRef<Path>, mut content: String) -> Result<()> {
+    let path_ref = path.as_ref();
+
+    // Log the path being written to
+    tracing::debug!("Writing to file: {:?}", path_ref);
+
     if !content.ends_with_newline() {
         content.push('\n');
     }
-    ctx.fs().write(path.as_ref(), content).await?;
-    Ok(())
+
+    // Try to write the file and provide better error context
+    match ctx.fs().write(path_ref, content).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            tracing::error!("Failed to write to file {:?}: {}", path_ref, e);
+            Err(eyre::eyre!("Failed to write to file {:?}: {}", path_ref, e))
+        },
+    }
 }
 
 /// Returns a prefix/suffix pair before and after the content dictated by `[start_line, end_line]`
@@ -950,4 +949,74 @@ mod tests {
         assert_eq!(terminal_width_required_for_line_count(100), 3);
         assert_eq!(terminal_width_required_for_line_count(999), 3);
     }
+}
+#[tokio::test]
+async fn test_fs_write_with_tilde_paths() {
+    // Create a test context
+    let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+    let mut stdout = std::io::stdout();
+
+    // Get the home directory from the context
+    let home_dir = ctx.env().home().unwrap_or_default();
+    println!("Test home directory: {:?}", home_dir);
+
+    // Create a file directly in the home directory first to ensure it exists
+    let home_path = ctx.fs().chroot_path(&home_dir);
+    println!("Chrooted home path: {:?}", home_path);
+
+    // Ensure the home directory exists
+    ctx.fs().create_dir_all(&home_path).await.unwrap();
+
+    let v = serde_json::json!({
+        "path": "~/file.txt",
+        "command": "create",
+        "file_text": "content in home file"
+    });
+
+    let result = serde_json::from_value::<FsWrite>(v)
+        .unwrap()
+        .invoke(&ctx, &mut stdout)
+        .await;
+
+    match &result {
+        Ok(_) => println!("Writing to ~/file.txt succeeded"),
+        Err(e) => println!("Writing to ~/file.txt failed: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Writing to ~/file.txt should succeed");
+
+    // Verify content was written correctly
+    let file_path = home_path.join("file.txt");
+    println!("Checking file at: {:?}", file_path);
+
+    let content_result = ctx.fs().read_to_string(&file_path).await;
+    match &content_result {
+        Ok(content) => println!("Read content: {:?}", content),
+        Err(e) => println!("Failed to read content: {:?}", e),
+    }
+
+    assert!(content_result.is_ok(), "Should be able to read from expanded path");
+    assert_eq!(content_result.unwrap(), "content in home file\n");
+
+    // Test with "~/nested/path/file.txt" to ensure deep paths work
+    let nested_dir = home_path.join("nested").join("path");
+    ctx.fs().create_dir_all(&nested_dir).await.unwrap();
+
+    let v = serde_json::json!({
+        "path": "~/nested/path/file.txt",
+        "command": "create",
+        "file_text": "content in nested path"
+    });
+
+    let result = serde_json::from_value::<FsWrite>(v)
+        .unwrap()
+        .invoke(&ctx, &mut stdout)
+        .await;
+
+    assert!(result.is_ok(), "Writing to ~/nested/path/file.txt should succeed");
+
+    // Verify nested path content
+    let nested_file_path = nested_dir.join("file.txt");
+    let nested_content = ctx.fs().read_to_string(&nested_file_path).await.unwrap();
+    assert_eq!(nested_content, "content in nested path\n");
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/2003

*Description of changes:*
- Updates `fs_read` tool to handle reading files that contain non utf-8 characters
- Updates `fs_read` tool to handle pattern searching ux bug where "Found X ..." was not on a newline

Before
<img width="1272" alt="Screenshot 2025-06-17 at 3 58 16 PM" src="https://github.com/user-attachments/assets/3934be1a-4783-4914-88d8-15cc0f21d1b0" />

<img width="1272" alt="Screenshot 2025-06-17 at 4 00 00 PM" src="https://github.com/user-attachments/assets/23bf2ad9-c246-4d77-8d87-a852275b4104" />


After
<img width="1272" alt="Screenshot 2025-06-17 at 4 01 15 PM" src="https://github.com/user-attachments/assets/6ef13ab6-5044-462a-9476-a3a64fa88c31" />

<img width="1272" alt="Screenshot 2025-06-17 at 4 02 02 PM" src="https://github.com/user-attachments/assets/1bd90fa5-9466-4cb7-b7d4-b6390d9fd6c8" />

<img width="1297" alt="Screenshot 2025-06-17 at 4 03 54 PM" src="https://github.com/user-attachments/assets/a306eaf8-2839-4f77-87f7-0078e9f8ad75" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
