### PR TITLE
Fix: not being able to run slash context subcommand

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/context.rs
+++ b/crates/chat-cli/src/cli/chat/cli/context.rs
@@ -39,25 +39,30 @@ pub enum ContextSubcommand {
     Show {
         /// Print out each matched file's content, hook configurations, and last
         /// session.conversation summary
+        #[arg(short, long)]
         expand: bool,
     },
     /// Add context rules (filenames or glob patterns)
     Add {
         /// Add to global rules (available in all profiles)
+        #[arg(short, long)]
         global: bool,
         /// Include even if matched files exceed size limits
+        #[arg(short, long)]
         force: bool,
         paths: Vec<String>,
     },
     /// Remove specified rules from current profile
     Remove {
         /// Remove specified rules globally
+        #[arg(short, long)]
         global: bool,
         paths: Vec<String>,
     },
     /// Remove all rules from current profile
     Clear {
         /// Remove global rules
+        #[arg(short, long)]
         global: bool,
     },
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A bool field without additional attributes is treated as a positional argument by default, but clap is trying to apply SetTrue action to it (which is for flags).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
