### PR TITLE
Fix: child process spawned for mcp no inheriting env vars from parent

### DIFF
--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -180,7 +180,8 @@ impl Client<StdioTransport> {
             command
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
+                .stderr(Stdio::piped())
+                .envs(std::env::vars());
 
             #[cfg(not(windows))]
             command.process_group(0);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
