### PR TITLE
feat(chat): autocompletion for q chat

### DIFF
--- a/crates/chat-cli/src/cli/chat/input_source.rs
+++ b/crates/chat-cli/src/cli/chat/input_source.rs
@@ -74,6 +74,11 @@ impl InputSource {
                 match curr_line {
                     Ok(line) => {
                         let _ = rl.add_history_entry(line.as_str());
+
+                        if let Some(helper) = rl.helper_mut() {
+                            helper.update_hinter_history(&line);
+                        }
+                        
                         Ok(Some(line))
                     },
                     Err(ReadlineError::Interrupted | ReadlineError::Eof) => Ok(None),

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -11,6 +11,7 @@ use rustyline::highlight::{
     CmdKind,
     Highlighter,
 };
+use rustyline::hint::Hinter as RustylineHinter;
 use rustyline::history::DefaultHistory;
 use rustyline::validate::{
     ValidationContext,
@@ -209,6 +210,62 @@ impl Completer for ChatCompleter {
     }
 }
 
+/// Custom hinter that provides shadowtext suggestions
+pub struct ChatHinter {
+    /// Command history for providing suggestions based on past commands
+    history: Vec<String>,
+}
+
+impl ChatHinter {
+    /// Creates a new ChatHinter instance
+    pub fn new() -> Self {
+        Self { history: Vec::new() }
+    }
+
+    /// Updates the history with a new command
+    pub fn update_history(&mut self, command: &str) {
+        if !command.trim().is_empty() {
+            self.history.push(command.to_string());
+        }
+    }
+
+    /// Finds the best hint for the current input
+    fn find_hint(&self, line: &str) -> Option<String> {
+        // If line is empty, no hint
+        if line.is_empty() {
+            return None;
+        }
+
+        // If line starts with a slash, try to find a command hint
+        if line.starts_with('/') {
+            return COMMANDS
+                .iter()
+                .find(|cmd| cmd.starts_with(line))
+                .map(|cmd| cmd[line.len()..].to_string());
+        }
+
+        // Try to find a hint from history
+        self.history
+            .iter()
+            .rev() // Start from most recent
+            .find(|cmd| cmd.starts_with(line) && cmd.len() > line.len())
+            .map(|cmd| cmd[line.len()..].to_string())
+    }
+}
+
+impl RustylineHinter for ChatHinter {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<Self::Hint> {
+        // Only provide hints when cursor is at the end of the line
+        if pos < line.len() {
+            return None;
+        }
+
+        self.find_hint(line)
+    }
+}
+
 /// Custom validator for multi-line input
 pub struct MultiLineValidator;
 
@@ -235,8 +292,15 @@ pub struct ChatHelper {
     #[rustyline(Completer)]
     completer: ChatCompleter,
     #[rustyline(Hinter)]
-    hinter: (),
+    hinter: ChatHinter,
     validator: MultiLineValidator,
+}
+
+impl ChatHelper {
+    /// Updates the history of the ChatHinter with a new command
+    pub fn update_hinter_history(&mut self, command: &str) {
+        self.hinter.update_history(command);
+    }
 }
 
 impl Validator for ChatHelper {
@@ -247,7 +311,7 @@ impl Validator for ChatHelper {
 
 impl Highlighter for ChatHelper {
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
-        Cow::Owned(format!("\x1b[1m{hint}\x1b[m"))
+        Cow::Owned(format!("\x1b[38;5;240m{hint}\x1b[m"))
     }
 
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
@@ -303,7 +367,7 @@ pub fn rl(
         .build();
     let h = ChatHelper {
         completer: ChatCompleter::new(sender, receiver),
-        hinter: (),
+        hinter: ChatHinter::new(),
         validator: MultiLineValidator,
     };
     let mut rl = Editor::with_config(config)?;
@@ -377,7 +441,7 @@ mod tests {
         let (_, prompt_response_receiver) = std::sync::mpsc::channel::<Vec<String>>();
         let helper = ChatHelper {
             completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
-            hinter: (),
+            hinter: ChatHinter::new(),
             validator: MultiLineValidator,
         };
 
@@ -393,7 +457,7 @@ mod tests {
         let (_, prompt_response_receiver) = std::sync::mpsc::channel::<Vec<String>>();
         let helper = ChatHelper {
             completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
-            hinter: (),
+            hinter: ChatHinter::new(),
             validator: MultiLineValidator,
         };
 
@@ -409,7 +473,7 @@ mod tests {
         let (_, prompt_response_receiver) = std::sync::mpsc::channel::<Vec<String>>();
         let helper = ChatHelper {
             completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
-            hinter: (),
+            hinter: ChatHinter::new(),
             validator: MultiLineValidator,
         };
 
@@ -425,7 +489,7 @@ mod tests {
         let (_, prompt_response_receiver) = std::sync::mpsc::channel::<Vec<String>>();
         let helper = ChatHelper {
             completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
-            hinter: (),
+            hinter: ChatHinter::new(),
             validator: MultiLineValidator,
         };
 
@@ -444,7 +508,7 @@ mod tests {
         let (_, prompt_response_receiver) = std::sync::mpsc::channel::<Vec<String>>();
         let helper = ChatHelper {
             completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
-            hinter: (),
+            hinter: ChatHinter::new(),
             validator: MultiLineValidator,
         };
 
@@ -452,5 +516,47 @@ mod tests {
         let invalid_prompt = "invalid prompt format";
         let highlighted = helper.highlight_prompt(invalid_prompt, true);
         assert_eq!(highlighted, invalid_prompt);
+    }
+
+    #[test]
+    fn test_chat_hinter_command_hint() {
+        let hinter = ChatHinter::new();
+
+        // Test hint for a command
+        let line = "/he";
+        let pos = line.len();
+        let empty_history = DefaultHistory::new();
+        let ctx = Context::new(&empty_history);
+
+        let hint = hinter.hint(line, pos, &ctx);
+        assert_eq!(hint, Some("lp".to_string()));
+
+        // Test hint when cursor is not at the end
+        let hint = hinter.hint(line, 1, &ctx);
+        assert_eq!(hint, None);
+
+        // Test hint for a non-existent command
+        let line = "/xyz";
+        let pos = line.len();
+        let hint = hinter.hint(line, pos, &ctx);
+        assert_eq!(hint, None);
+    }
+
+    #[test]
+    fn test_chat_hinter_history_hint() {
+        let mut hinter = ChatHinter::new();
+
+        // Add some history
+        hinter.update_history("Hello, world!");
+        hinter.update_history("How are you?");
+
+        // Test hint from history
+        let line = "How";
+        let pos = line.len();
+        let empty_history = DefaultHistory::new();
+        let ctx = Context::new(&empty_history);
+
+        let hint = hinter.hint(line, pos, &ctx);
+        assert_eq!(hint, Some(" are you?".to_string()));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
resolve https://github.com/aws/amazon-q-developer-cli/issues/901

*Description of changes:*
This PR implements shadow text autocompletion for q chat, enhancing the user experience by suggesting commands based on command history and predefined commands.

https://github.com/user-attachments/assets/99773b2d-287c-47e1-b607-1ec0670c6b59

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
