### PR TITLE
fix: inconsistency in /save and /load behavior with regard to file ex…

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/persist.rs
+++ b/crates/chat-cli/src/cli/chat/cli/persist.rs
@@ -1,17 +1,9 @@
 use clap::Subcommand;
 use crossterm::execute;
-use crossterm::style::{
-    self,
-    Attribute,
-    Color,
-};
+use crossterm::style::{self, Attribute, Color};
 
 use crate::cli::ConversationState;
-use crate::cli::chat::{
-    ChatError,
-    ChatSession,
-    ChatState,
-};
+use crate::cli::chat::{ChatError, ChatSession, ChatState};
 use crate::platform::Context;
 
 #[deny(missing_docs)]
@@ -76,7 +68,23 @@ impl PersistSubcommand {
                 )?;
             },
             Self::Load { path } => {
-                let contents = tri!(ctx.fs.read_to_string(&path).await, "import from", &path);
+                // Try the original path first
+                let original_result = ctx.fs.read_to_string(&path).await;
+
+                // If the original path fails and doesn't end with .json, try with .json appended
+                let contents = if original_result.is_err() && !path.ends_with(".json") {
+                    let json_path = format!("{}.json", path);
+                    match ctx.fs.read_to_string(&json_path).await {
+                        Ok(content) => content,
+                        Err(_) => {
+                            // If both paths fail, return the original error for better user experience
+                            tri!(original_result, "import from", &path)
+                        },
+                    }
+                } else {
+                    tri!(original_result, "import from", &path)
+                };
+
                 let mut new_state: ConversationState = tri!(serde_json::from_str(&contents), "import from", &path);
                 new_state.reload_serialized_state(ctx).await;
                 session.conversation = new_state;


### PR DESCRIPTION
*Issue #, if available:*
resolve: https://github.com/aws/amazon-q-developer-cli/issues/1918

*Description of changes:*
This PR allows q chat to automatically grant .json and retry if the .json extension is not present when the load command is executed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
