### PR TITLE
Added cyan response prefix for improved readability

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1500,6 +1500,7 @@ impl ChatSession {
         let mut ended = false;
         let mut parser = ResponseParser::new(response);
         let mut state = ParseState::new(Some(self.terminal_width()));
+        let mut response_prefix_printed = false;
 
         let mut tool_uses = Vec::new();
         let mut tool_name_being_recvd: Option<String> = None;
@@ -1529,6 +1530,17 @@ impl ChatSession {
                             tool_name_being_recvd = Some(name);
                         },
                         parser::ResponseEvent::AssistantText(text) => {
+                            // Add Q response prefix before the first assistant text
+                            if !response_prefix_printed && !text.trim().is_empty() {
+                                // Print the Q response prefix with cyan color
+                                execute!(
+                                    self.stdout,
+                                    style::SetForegroundColor(Color::Cyan),
+                                    style::Print("> "),
+                                    style::SetForegroundColor(Color::Reset)
+                                )?;
+                                response_prefix_printed = true;
+                            }
                             buf.push_str(&text);
                         },
                         parser::ResponseEvent::ToolUse(tool_use) => {


### PR DESCRIPTION
*Description of changes:*
This PR adds a visual response prefix to Amazon Q chat responses to improve readability and user experience. Each response from Amazon Q now begins with a newline and a cyan-colored "> " prefix, making it easier to distinguish between user input and assistant output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.