### PR TITLE
fix: add login check for sigv4 chat support

### DIFF
--- a/crates/q_cli/src/util/mod.rs
+++ b/crates/q_cli/src/util/mod.rs
@@ -291,7 +291,7 @@ pub fn dialoguer_theme() -> ColorfulTheme {
 }
 
 pub async fn assert_logged_in() -> Result<(), Error> {
-    if !fig_util::system_info::in_cloudshell() && !fig_auth::is_logged_in().await {
+    if !(std::env::var("AMAZON_Q_SIGV4").is_ok_and(|v| !v.is_empty()) || fig_auth::is_logged_in().await) {
         bail!(
             "You are not logged in, please log in with {}",
             format!("{CLI_BINARY_NAME} login",).bold()


### PR DESCRIPTION
*Description of changes:*
- Adding support for Sigv4 with the `q` binary when spawning the `qchat` binary by assuming the user is logged in if the `AMAZON_Q_SIGV4` env var is set. This is the same env var used in the `qchat` binary for using sigv4.
- CloudShell checking is deprecated and not used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
