### PR TITLE
Feat/save on quit

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -9,6 +9,7 @@ pub mod model;
 pub mod persist;
 pub mod profile;
 pub mod prompts;
+pub mod quit;
 pub mod subscribe;
 pub mod tools;
 pub mod usage;
@@ -25,16 +26,12 @@ use model::ModelArgs;
 use persist::PersistSubcommand;
 use profile::ProfileSubcommand;
 use prompts::PromptsArgs;
+use quit::QuitArgs;
 use tools::ToolsArgs;
 
 use crate::cli::chat::cli::subscribe::SubscribeArgs;
 use crate::cli::chat::cli::usage::UsageArgs;
-use crate::cli::chat::{
-    ChatError,
-    ChatSession,
-    ChatState,
-    EXTRA_HELP,
-};
+use crate::cli::chat::{ChatError, ChatSession, ChatState, EXTRA_HELP};
 use crate::cli::issue;
 use crate::os::Os;
 
@@ -44,7 +41,7 @@ use crate::os::Os;
 pub enum SlashCommand {
     /// Quit the application
     #[command(aliases = ["q", "exit"])]
-    Quit,
+    Quit(QuitArgs),
     /// Clear the conversation history
     Clear(ClearArgs),
     /// Manage profiles
@@ -86,7 +83,7 @@ pub enum SlashCommand {
 impl SlashCommand {
     pub async fn execute(self, os: &mut Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         match self {
-            Self::Quit => Ok(ChatState::Exit),
+            Self::Quit(args) => args.execute(os, session).await,
             Self::Clear(args) => args.execute(session).await,
             Self::Profile(subcommand) => subcommand.execute(os, session).await,
             Self::Context(args) => args.execute(os, session).await,

--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -31,7 +31,12 @@ use tools::ToolsArgs;
 
 use crate::cli::chat::cli::subscribe::SubscribeArgs;
 use crate::cli::chat::cli::usage::UsageArgs;
-use crate::cli::chat::{ChatError, ChatSession, ChatState, EXTRA_HELP};
+use crate::cli::chat::{
+    ChatError,
+    ChatSession,
+    ChatState,
+    EXTRA_HELP,
+};
 use crate::cli::issue;
 use crate::os::Os;
 

--- a/crates/chat-cli/src/cli/chat/cli/quit.rs
+++ b/crates/chat-cli/src/cli/chat/cli/quit.rs
@@ -1,0 +1,23 @@
+use clap::Args;
+
+use crate::cli::chat::cli::persist::PersistSubcommand;
+use crate::cli::chat::{ChatError, ChatSession, ChatState};
+use crate::os::Os;
+
+#[derive(Debug, PartialEq, Args)]
+pub struct QuitArgs {
+    /// Save the conversation before quitting
+    #[arg(long)]
+    pub save: Option<String>,
+}
+
+impl QuitArgs {
+    pub async fn execute(self, os: &Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+        if let Some(path) = self.save {
+            // Save conversation before quitting
+            let persist_cmd = PersistSubcommand::Save { path, force: false };
+            persist_cmd.execute(os, session).await?;
+        }
+        Ok(ChatState::Exit)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Users can now save on exit by using the `/quit --save [filename]` flag. Clap automatically adds this to the help text when running `/quit --help`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
