### PR TITLE
feat(chat): add --script option to run Q scripts

### DIFF
--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -4,6 +4,7 @@ mod diagnostics;
 mod feed;
 mod issue;
 mod mcp;
+mod script;
 mod settings;
 mod user;
 
@@ -355,7 +356,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })),
             verbose: 2,
             help_all: false,
@@ -394,7 +396,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })
         );
     }
@@ -410,7 +413,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })
         );
     }
@@ -426,7 +430,8 @@ mod test {
                 model: None,
                 trust_all_tools: true,
                 trust_tools: None,
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })
         );
     }
@@ -442,7 +447,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: true
+                non_interactive: true,
+                script: None,
             })
         );
         assert_parse!(
@@ -454,7 +460,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: true
+                non_interactive: true,
+                script: None,
             })
         );
     }
@@ -470,7 +477,8 @@ mod test {
                 model: None,
                 trust_all_tools: true,
                 trust_tools: None,
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })
         );
     }
@@ -486,7 +494,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: Some(vec!["".to_string()]),
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })
         );
     }
@@ -502,7 +511,8 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: Some(vec!["fs_read".to_string(), "fs_write".to_string()]),
-                non_interactive: false
+                non_interactive: false,
+                script: None,
             })
         );
     }

--- a/crates/chat-cli/src/cli/script.rs
+++ b/crates/chat-cli/src/cli/script.rs
@@ -1,0 +1,145 @@
+use std::io;
+
+use eyre::Result;
+use tokio::fs;
+
+/// read_q_script reads the file passed in and returns its contents. If it's first line begins with
+/// a shebang (#!), that line and consecutive lines beginning with a '#' character are skipped.
+pub async fn read_q_script(script: &str) -> Result<String, io::Error> {
+    match fs::read_to_string(&script).await {
+        Ok(content) => {
+            let mut lines = content.lines().peekable();
+            let mut result_lines = Vec::new();
+
+            // Only skip the first line if it starts with '#!'
+            if lines.peek().is_some_and(|line| line.starts_with("#!")) {
+                lines.next();
+                // Skip consecutive comment lines after shebang
+                while lines.peek().is_some_and(|line| line.starts_with('#')) {
+                    lines.next();
+                }
+            }
+
+            result_lines.extend(lines);
+            Ok(result_lines.join("\n"))
+        },
+        Err(e) => Err(e),
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn create_temp_script(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_and_consecutive_comments() {
+        let content =
+            "#!/usr/bin/env q\n# This is a comment\n# Another comment\nactual content\n# Later comment\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "actual content\n# Later comment\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_no_comments() {
+        let content = "#!/usr/bin/env q\nactual content\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "actual content\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_script_without_shebang_with_comments() {
+        let content = "# This is a comment\nactual content\n# Later comment\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(
+            result.unwrap(),
+            "# This is a comment\nactual content\n# Later comment\nmore content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_script_without_shebang_no_comments() {
+        let content = "actual content\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "actual content\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_only_shebang() {
+        let content = "#!/usr/bin/env q";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_and_only_comments() {
+        let content = "#!/usr/bin/env q\n# Comment 1\n# Comment 2";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_non_shebang_hash_first_line() {
+        let content = "#not a shebang\nactual content\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "#not a shebang\nactual content\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_empty_script() {
+        let content = "";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_mixed_content() {
+        let content = "#!/usr/bin/env q\n# Header comment\n# Another header comment\n\nactual content\n# Inline comment\nmore content\n\n# Final comment";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(
+            result.unwrap(),
+            "\nactual content\n# Inline comment\nmore content\n\n# Final comment"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nonexistent_file() {
+        let result = read_q_script("/nonexistent/file.q").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_and_empty_lines() {
+        let content = "#!/usr/bin/env q\n# Comment\n\n\nactual content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "\n\nactual content");
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This allows using the Q cli as an intepreter for a script.

E.g.

```
#!/usr/bin/env q chat --no-interactive --trust-tools=a,b --script
# Script for performing analysis on X, Y, and Z

Only use tools a and b
Examine X, Y and Z using those tools and display a short summary, highlighting any concerns.

```

`--no-interactive` is optional, if not passed the script is passed as the initial input and then Q cli enters standard interactive mode.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
