### PR TITLE
feat: added env variable USER_PROMPT and enabled removal + sanitizing of en…

### DIFF
--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -117,7 +117,7 @@ impl ConversationState {
         };
         
         // Remove any potentially problematic characters
-        return truncated.replace(|c: char| c.is_control() && c != '\n' && c != '\r' && c != '\t', "")
+        return truncated.replace(|c: char| c.is_control() && c != '\n' && c != '\r' && c != '\t' && c != '$', "")
     }
     pub async fn new(
         os: &mut Os,

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -477,25 +477,6 @@ pub struct ChatSession {
 }
 
 impl ChatSession {
-    /// Sanitizes user input for environment variable usage
-    fn sanitize_env_value(input: &str) -> String {
-        // Limit the size of input to first 4096 characters
-        let truncated = if input.len() > 4096 {
-            &input[0..4096]
-        } else {
-            input
-        };
-        
-        // Remove any potentially problematic characters
-        truncated.replace(|c: char| c.is_control() && c != '\n' && c != '\r' && c != '\t', "")
-    }
-    
-    /// Clears the USER_PROMPT environment variable
-    fn clear_user_prompt_env() {
-        unsafe { 
-            std::env::remove_var("USER_PROMPT") 
-        };
-    }
     
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
@@ -823,10 +804,7 @@ impl ChatSession {
 }
 
 impl Drop for ChatSession {
-    fn drop(&mut self) {
-        // Clear USER_PROMPT environment variable for security when session ends
-        Self::clear_user_prompt_env();
-        
+    fn drop(&mut self) {        
         if let Some(spinner) = &mut self.spinner {
             spinner.stop();
         }
@@ -1168,10 +1146,7 @@ impl ChatSession {
     }
 
     /// Read input from the user.
-    async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {
-        // Clear any previous USER_PROMPT environment variable
-        Self::clear_user_prompt_env();
-        
+    async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {        
         execute!(self.stderr, cursor::Show)?;
 
         // Check token usage and display warnings if needed
@@ -1240,11 +1215,6 @@ impl ChatSession {
         let user_input = match self.read_user_input(&prompt, false) {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
-        };
-
-        // Set sanitized user prompt as environment variable
-        unsafe {
-            std::env::set_var("USER_PROMPT", &Self::sanitize_env_value(&user_input))
         };
 
         self.conversation.append_user_transcript(&user_input);

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -477,26 +477,6 @@ pub struct ChatSession {
 }
 
 impl ChatSession {
-    /// Sanitizes user input for environment variable usage
-    // fn sanitize_env_value(input: &str) -> String {
-    //     // Limit the size of input to first 4096 characters
-    //     let truncated = if input.len() > 4096 {
-    //         &input[0..4096]
-    //     } else {
-    //         input
-    //     };
-        
-    //     // Remove any potentially problematic characters
-    //     truncated.replace(|c: char| c.is_control() && c != '\n' && c != '\r' && c != '\t', "")
-    // }
-    
-    // /// Clears the USER_PROMPT environment variable
-    // fn clear_user_prompt_env() {
-    //     unsafe { 
-    //         std::env::remove_var("USER_PROMPT") 
-    //     };
-    // }
-    
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         os: &mut Os,
@@ -823,9 +803,7 @@ impl ChatSession {
 }
 
 impl Drop for ChatSession {
-    fn drop(&mut self) {
-        // Clear USER_PROMPT environment variable for security when session ends
-        
+    fn drop(&mut self) {        
         if let Some(spinner) = &mut self.spinner {
             spinner.stop();
         }
@@ -1167,9 +1145,7 @@ impl ChatSession {
     }
 
     /// Read input from the user.
-    async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {
-        // Clear any previous USER_PROMPT environment variable
-        
+    async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {        
         execute!(self.stderr, cursor::Show)?;
 
         // Check token usage and display warnings if needed
@@ -1239,11 +1215,6 @@ impl ChatSession {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
         };
-
-        // Set sanitized user prompt as environment variable
-        // unsafe {
-        //     std::env::set_var("USER_PROMPT", &Self::sanitize_env_value(&user_input))
-        // };
 
         self.conversation.append_user_transcript(&user_input);
         Ok(ChatState::HandleInput { input: user_input })

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -477,6 +477,26 @@ pub struct ChatSession {
 }
 
 impl ChatSession {
+    /// Sanitizes user input for environment variable usage
+    fn sanitize_env_value(input: &str) -> String {
+        // Limit the size of input to first 4096 characters
+        let truncated = if input.len() > 4096 {
+            &input[0..4096]
+        } else {
+            input
+        };
+        
+        // Remove any potentially problematic characters
+        truncated.replace(|c: char| c.is_control() && c != '\n' && c != '\r' && c != '\t', "")
+    }
+    
+    /// Clears the USER_PROMPT environment variable
+    fn clear_user_prompt_env() {
+        unsafe { 
+            std::env::remove_var("USER_PROMPT") 
+        };
+    }
+    
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         os: &mut Os,
@@ -804,6 +824,9 @@ impl ChatSession {
 
 impl Drop for ChatSession {
     fn drop(&mut self) {
+        // Clear USER_PROMPT environment variable for security when session ends
+        Self::clear_user_prompt_env();
+        
         if let Some(spinner) = &mut self.spinner {
             spinner.stop();
         }
@@ -1146,6 +1169,9 @@ impl ChatSession {
 
     /// Read input from the user.
     async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {
+        // Clear any previous USER_PROMPT environment variable
+        Self::clear_user_prompt_env();
+        
         execute!(self.stderr, cursor::Show)?;
 
         // Check token usage and display warnings if needed
@@ -1214,6 +1240,11 @@ impl ChatSession {
         let user_input = match self.read_user_input(&prompt, false) {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
+        };
+
+        // Set sanitized user prompt as environment variable
+        unsafe {
+            std::env::set_var("USER_PROMPT", &Self::sanitize_env_value(&user_input))
         };
 
         self.conversation.append_user_transcript(&user_input);

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -477,6 +477,25 @@ pub struct ChatSession {
 }
 
 impl ChatSession {
+    /// Sanitizes user input for environment variable usage
+    // fn sanitize_env_value(input: &str) -> String {
+    //     // Limit the size of input to first 4096 characters
+    //     let truncated = if input.len() > 4096 {
+    //         &input[0..4096]
+    //     } else {
+    //         input
+    //     };
+        
+    //     // Remove any potentially problematic characters
+    //     truncated.replace(|c: char| c.is_control() && c != '\n' && c != '\r' && c != '\t', "")
+    // }
+    
+    // /// Clears the USER_PROMPT environment variable
+    // fn clear_user_prompt_env() {
+    //     unsafe { 
+    //         std::env::remove_var("USER_PROMPT") 
+    //     };
+    // }
     
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
@@ -804,7 +823,9 @@ impl ChatSession {
 }
 
 impl Drop for ChatSession {
-    fn drop(&mut self) {        
+    fn drop(&mut self) {
+        // Clear USER_PROMPT environment variable for security when session ends
+        
         if let Some(spinner) = &mut self.spinner {
             spinner.stop();
         }
@@ -1146,7 +1167,9 @@ impl ChatSession {
     }
 
     /// Read input from the user.
-    async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {        
+    async fn prompt_user(&mut self, os: &Os, skip_printing_tools: bool) -> Result<ChatState, ChatError> {
+        // Clear any previous USER_PROMPT environment variable
+        
         execute!(self.stderr, cursor::Show)?;
 
         // Check token usage and display warnings if needed
@@ -1216,6 +1239,11 @@ impl ChatSession {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
         };
+
+        // Set sanitized user prompt as environment variable
+        // unsafe {
+        //     std::env::set_var("USER_PROMPT", &Self::sanitize_env_value(&user_input))
+        // };
 
         self.conversation.append_user_transcript(&user_input);
         Ok(ChatState::HandleInput { input: user_input })


### PR DESCRIPTION



Description of changes:
Added support for retrieving current user prompts through addition of a USER_PROMPT environment variable. The variable is invoked and created whenever a prompt is received and cleared upon subsequent invocations. In order to consider the case for long prompts, the env variable is limited to the first 4096 characters within a user's prompt. The prompt is also cleared upon the closing of a Q CLI session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
