### PR TITLE
fix: remove cw telemetry client for sigv4, revert skipping banner printing to stderr in noninteractive mode

### DIFF
--- a/crates/chat-cli/src/api_client/mod.rs
+++ b/crates/chat-cli/src/api_client/mod.rs
@@ -90,7 +90,7 @@ impl ApiClient {
             .region(endpoint.region.clone())
             .credentials_provider(credentials)
             .timeout_config(timeout_config(database))
-            .retry_config(RetryConfig::adaptive())
+            .retry_config(retry_config())
             .load()
             .await;
 
@@ -137,7 +137,7 @@ impl ApiClient {
                             .region(endpoint.region.clone())
                             .credentials_provider(credentials_chain)
                             .timeout_config(timeout_config(database))
-                            .retry_config(RetryConfig::adaptive())
+                            .retry_config(retry_config())
                             .load()
                             .await,
                     )
@@ -461,6 +461,10 @@ fn timeout_config(database: &Database) -> TimeoutConfig {
         .operation_attempt_timeout(timeout)
         .connect_timeout(timeout)
         .build()
+}
+
+fn retry_config() -> RetryConfig {
+    RetryConfig::standard().with_max_attempts(1)
 }
 
 pub fn stalled_stream_protection_config() -> StalledStreamProtectionConfig {

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -874,7 +874,6 @@ impl Default for ChatState {
 impl ChatSession {
     async fn spawn(&mut self, os: &mut Os) -> Result<()> {
         let is_small_screen = self.terminal_width() < GREETING_BREAK_POINT;
-        let mut interactive_text: Vec<u8> = Vec::new();
         if os
             .database
             .settings
@@ -889,20 +888,20 @@ impl ChatSession {
                 },
             };
 
-            execute!(interactive_text, style::Print(welcome_text), style::Print("\n\n"),)?;
+            execute!(self.stderr, style::Print(welcome_text), style::Print("\n\n"),)?;
 
             let tip = ROTATING_TIPS[usize::try_from(rand::random::<u32>()).unwrap_or(0) % ROTATING_TIPS.len()];
             if is_small_screen {
                 // If the screen is small, print the tip in a single line
                 execute!(
-                    interactive_text,
+                    self.stderr,
                     style::Print("💡 ".to_string()),
                     style::Print(tip),
                     style::Print("\n")
                 )?;
             } else {
                 draw_box(
-                    &mut interactive_text,
+                    &mut self.stderr,
                     "Did you know?",
                     tip,
                     GREETING_BREAK_POINT,
@@ -911,7 +910,7 @@ impl ChatSession {
             }
 
             execute!(
-                interactive_text,
+                self.stderr,
                 style::Print("\n"),
                 style::Print(match is_small_screen {
                     true => SMALL_SCREEN_POPULAR_SHORTCUTS,
@@ -924,38 +923,30 @@ impl ChatSession {
                         .dark_grey()
                 )
             )?;
-            execute!(
-                interactive_text,
-                style::Print("\n"),
-                style::SetForegroundColor(Color::Reset)
-            )?;
+            execute!(self.stderr, style::Print("\n"), style::SetForegroundColor(Color::Reset))?;
         }
 
         if self.all_tools_trusted() {
             queue!(
-                interactive_text,
+                self.stderr,
                 style::Print(format!(
                     "{}{TRUST_ALL_TEXT}\n\n",
                     if !is_small_screen { "\n" } else { "" }
                 ))
             )?;
         }
+        self.stderr.flush()?;
 
         if let Some(ref id) = self.conversation.model {
             if let Some(model_option) = MODEL_OPTIONS.iter().find(|option| option.model_id == *id) {
                 execute!(
-                    interactive_text,
+                    self.stderr,
                     style::SetForegroundColor(Color::Cyan),
                     style::Print(format!("🤖 You are chatting with {}\n", model_option.name)),
                     style::SetForegroundColor(Color::Reset),
                     style::Print("\n")
                 )?;
             }
-        }
-
-        if self.interactive {
-            self.stderr.write_all(&interactive_text)?;
-            self.stderr.flush()?;
         }
 
         if let Some(user_input) = self.initial_input.take() {


### PR DESCRIPTION
*Description of changes:*
- Printing the banner and other various text to stderr in non-interactive mode, since this is machine-readable output and users should not be depending on this in non-interactive use cases.
- Removing the cw telemetry client if sigv4 auth is being used, since cw telemetry requires bearer token auth

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
