### PR TITLE
fix: stream responses correctly

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1403,6 +1403,13 @@ impl ChatSession {
             self.tool_use_status = ToolUseStatus::Idle;
 
             if self.pending_tool_index.is_some() {
+                // If the user just enters "n", replace the message we send to the model with
+                // something more substantial.
+                let user_input = if ["n", "N"].contains(&user_input.trim()) {
+                    "I deny this tool request. Ask a follow up question clarifying the expected action".to_string()
+                } else {
+                    user_input
+                };
                 self.conversation.abandon_tool_use(&self.tool_uses, user_input);
             } else {
                 self.conversation.set_next_user_message(user_input).await;

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1784,7 +1784,7 @@ impl ChatSession {
             // Print the response for normal cases
             loop {
                 let input = Partial::new(&buf[offset..]);
-                match interpret_markdown(input, &mut self.stdout, &mut state) {
+                match interpret_markdown(input, &mut self.stderr, &mut state) {
                     Ok(parsed) => {
                         offset += parsed.offset_from(&input);
                         self.stderr.flush()?;


### PR DESCRIPTION
*Description of changes:*
- Resolve the stream parsing regression to go back to the previous behavior of continually printing the assistant response rather than line-buffered printing
- Changing the message we send to the model when the user enters 'n' for a tool use deny to something more meaningful.

Example chat flow with 'n':
<img width="854" alt="Screenshot 2025-06-27 at 10 55 44 AM" src="https://github.com/user-attachments/assets/09eb8398-27c9-403b-a052-e446202113c7" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
