### PR TITLE
feat: implement database setting for trusting tools

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -255,6 +255,7 @@ impl ChatArgs {
             .build(os, Box::new(std::io::stderr()), !self.non_interactive)
             .await?;
         let tool_config = tool_manager.load_tools(os, &mut stderr).await?;
+
         let mut tool_permissions = ToolPermissions::new(tool_config.len());
 
         if self.trust_all_tools {
@@ -279,6 +280,9 @@ impl ChatArgs {
                     tool_permissions.untrust_tool(&tool.name);
                 }
             }
+        } else {
+            // CLI args has precendence over Database config
+            tool_permissions.trust_from_database(&os.database);
         }
 
         ChatSession::new(

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -39,6 +39,8 @@ use use_aws::UseAws;
 
 use super::consts::MAX_TOOL_RESPONSE_SIZE;
 use super::util::images::RichImageBlocks;
+use crate::database::Database;
+use crate::database::settings::Setting;
 use crate::os::Os;
 
 /// Represents an executable tool use.
@@ -222,6 +224,15 @@ impl ToolPermissions {
         }
 
         self.permissions.contains_key(tool_name)
+    }
+
+    pub fn trust_from_database(&mut self, database: &Database) {
+        database
+            .settings
+            .get_array::<String>(Setting::TrustedTools)
+            .into_iter()
+            .flatten()
+            .for_each(|tool_name| self.trust_tool(&tool_name));
     }
 
     /// Provide default permission labels for the built-in set of tools.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/1804

*Description of changes:*
Implement a new database setting that allows selectively trusting tools.

Specially useful for not breaking the flow when using MCP tools that don't have any side-effects e.g. `search_website`.

### Demo

https://github.com/user-attachments/assets/a938db97-fdef-49d1-8c85-b9dfb6b48615

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
