### PR TITLE
chore: hide /knowledge command, reduce tips width

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -55,7 +55,7 @@ pub enum SlashCommand {
     Context(ContextSubcommand),
     /// (Beta) Manage knowledge base for persistent context storage. Requires "q settings
     /// chat.enableKnowledge true"
-    #[command(subcommand)]
+    #[command(subcommand, hide = true)]
     Knowledge(KnowledgeSubcommand),
     /// Open $EDITOR (defaults to vi) to compose a prompt
     #[command(name = "editor")]

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -144,11 +144,14 @@ pub const EXTRA_HELP: &str = color_print::cstr! {"
 <black!>You can now configure the Amazon Q CLI to use MCP servers. \nLearn how: https://docs.aws.amazon.com/en_us/amazonq/latest/qdeveloper-ug/command-line-mcp.html</black!>
 
 <cyan,em>Tips:</cyan,em>
-<em>!{command}</em>            <black!>Quickly execute a command in your current session</black!>
-<em>Ctrl(^) + j</em>           <black!>Insert new-line to provide multi-line prompt. Alternatively, [Alt(⌥) + Enter(⏎)]</black!>
-<em>Ctrl(^) + s</em>           <black!>Fuzzy search commands and context files. Use Tab to select multiple items.</black!>
-                      <black!>Change the keybind to ctrl+x with: q settings chat.skimCommandKey x (where x is any key)</black!>
-<em>chat.editMode</em>         <black!>Set editing mode (vim or emacs) using: q settings chat.editMode vi/emacs</black!>
+<em>!{command}</em>          <black!>Quickly execute a command in your current session</black!>
+<em>Ctrl(^) + j</em>         <black!>Insert new-line to provide multi-line prompt</black!>
+                    <black!>Alternatively, [Alt(⌥) + Enter(⏎)]</black!>
+<em>Ctrl(^) + s</em>         <black!>Fuzzy search commands and context files</black!>
+                    <black!>Use Tab to select multiple items</black!>
+                    <black!>Change the keybind using: q settings chat.skimCommandKey x</black!>
+<em>chat.editMode</em>       <black!>The prompt editing mode (vim or emacs)</black!>
+                    <black!>Change using: q settings chat.skimCommandKey x</black!>
 "};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Args)]
@@ -353,13 +356,10 @@ const ROTATING_TIPS: [&str; 16] = [
 
 const GREETING_BREAK_POINT: usize = 80;
 
-const POPULAR_SHORTCUTS: &str = color_print::cstr! {
-"<black!><green!>/help</green!> all commands                      <em>•</em>  <green!>ctrl + j</green!> new lines
-<green!>ctrl + s</green!> fuzzy search                   <em>•</em>  <green!>ctrl + f</green!> accept completion</black!>"};
+const POPULAR_SHORTCUTS: &str = color_print::cstr! {"<black!><green!>/help</green!> all commands  <em>•</em>  <green!>ctrl + j</green!> new lines  <em>•</em>  <green!>ctrl + s</green!> fuzzy search</black!>"};
 const SMALL_SCREEN_POPULAR_SHORTCUTS: &str = color_print::cstr! {"<black!><green!>/help</green!> all commands
 <green!>ctrl + j</green!> new lines
 <green!>ctrl + s</green!> fuzzy search
-<green!>ctrl + f</green!> accept completion
 </black!>"};
 
 const RESPONSE_TIMEOUT_CONTENT: &str = "Response timed out - message took too long to generate";

--- a/feed.json
+++ b/feed.json
@@ -12,17 +12,13 @@
     },
     {
       "type": "release",
-      "date": "2025-06-27",
+      "date": "2025-06-30",
       "version": "1.12.2",
       "title": "Version 1.12.2",
       "changes": [
         {
           "type": "added",
-          "description": "(Beta) The `/knowledge` command in `q chat`, a knowledge base with semantic search capabilities. Enable it with `q settings chat.enableKnowledge true` - [#101](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/101)"
-        },
-        {
-          "type": "added",
-          "description": "Autocompletion with ghost text in `q chat` - [#288](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/288)"
+          "description": "Autocompletion with ghost text in `q chat`. Accept completions using right arrow or `Ctrl + f` - [#288](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/288)"
         },
         {
           "type": "added",


### PR DESCRIPTION
*Description of changes:*
- Removing the `/knowledge` subcommand from the feed and help, since it needs more polish before any public advertising.
- Removing the "accept completions" tip, reverting back to the same format we had before.
- Reducing the length of the printed tips in `/help` to support smaller terminal sizes, since at the moment we don't properly implement word wrapping.

Updated `/help` visual:
<img width="1025" alt="Screenshot 2025-06-30 at 9 20 08 AM" src="https://github.com/user-attachments/assets/4c3a4d75-1c1f-45fd-bc4f-7597f0cb1c72" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
