### PR TITLE
fix: newline printing on requests, panic with /prompts

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/prompts.rs
+++ b/crates/chat-cli/src/cli/chat/cli/prompts.rs
@@ -170,8 +170,10 @@ impl PromptsArgs {
                             .is_some_and(|args| !args.is_empty())
                         {
                             let name_width = UnicodeWidthStr::width(bundle.prompt_get.name.as_str());
-                            let padding = arg_pos.saturating_sub(name_width) - UnicodeWidthStr::width("- ");
-                            " ".repeat(padding)
+                            let padding = arg_pos
+                                .saturating_sub(name_width)
+                                .saturating_sub(UnicodeWidthStr::width("- "));
+                            " ".repeat(padding.max(1))
                         } else {
                             "\n".to_owned()
                         }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1427,7 +1427,6 @@ impl ChatSession {
             queue!(self.stderr, style::SetForegroundColor(Color::Magenta))?;
             queue!(self.stderr, style::SetForegroundColor(Color::Reset))?;
             queue!(self.stderr, cursor::Hide)?;
-            execute!(self.stderr, style::Print("\n"))?;
 
             if self.interactive {
                 self.spinner = Some(Spinner::new(Spinners::Dots, "Thinking...".to_owned()));
@@ -1631,10 +1630,8 @@ impl ChatSession {
             queue!(
                 self.stderr,
                 style::SetForegroundColor(Color::Reset),
-                terminal::Clear(terminal::ClearType::CurrentLine),
                 cursor::MoveToColumn(0),
                 cursor::Show,
-                cursor::MoveUp(1),
                 terminal::Clear(terminal::ClearType::CurrentLine),
             )?;
         }


### PR DESCRIPTION
*Description of changes:*
- Removing an unnecessary moveup command when printing an assistant response
- Resolving a panic issue with large prompt names in the `/prompts` command

`/prompts` output examples:
<img width="928" alt="Screenshot 2025-06-30 at 12 37 10 PM" src="https://github.com/user-attachments/assets/3bc1ced7-df0d-4da4-9317-4654497eb278" />
<img width="1008" alt="Screenshot 2025-06-30 at 12 37 31 PM" src="https://github.com/user-attachments/assets/eeb0fbc9-eee8-4b90-a8ff-e6b4432353fb" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
