### PR TITLE
(feat): Add support for batch file reading in fs_read tool

### DIFF
--- a/crates/chat-cli/src/cli/chat/message.rs
+++ b/crates/chat-cli/src/cli/chat/message.rs
@@ -255,6 +255,7 @@ impl From<InvokeOutput> for ToolUseResultBlock {
             OutputKind::Text(text) => Self::Text(text),
             OutputKind::Json(value) => Self::Json(value),
             OutputKind::Images(_) => Self::Text("See images data supplied".to_string()),
+            OutputKind::Mixed { text, .. } => ToolUseResultBlock::Text(text),
         }
     }
 }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1523,6 +1523,10 @@ impl ChatSession {
                         OutputKind::Images(ref image) => {
                             image_blocks.extend(image.clone());
                         },
+                        OutputKind::Mixed { ref text, ref images } => {
+                            debug!("Output is Mixed: text = {:?}, images = {}", text, images.len());
+                            image_blocks.extend(images.clone());
+                        },
                     }
 
                     debug!("tool result output: {:#?}", result);

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -370,6 +370,8 @@ const TRUST_ALL_TEXT: &str = color_print::cstr! {"<green!>All tools are now trus
 const TOOL_BULLET: &str = " ● ";
 const CONTINUATION_LINE: &str = " ⋮ ";
 const PURPOSE_ARROW: &str = " ↳ ";
+const SUCCESS_TICK: &str = " ✓ ";
+const ERROR_EXCLAMATION: &str = " ❗ ";
 
 /// Enum used to denote the origin of a tool use event
 enum ToolUseStatus {

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -1192,7 +1192,6 @@ mod tests {
             .invoke(&os, &mut stdout)
             .await
             .unwrap();
-        print!("output {:?}", output);
         // All text operations should return combined text
         if let OutputKind::Text(text) = output.output {
             // Check all operations are included

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -438,6 +438,71 @@ pub fn display_purpose(purpose: Option<&String>, updates: &mut impl Write) -> Re
     Ok(())
 }
 
+/// Helper function to format function results with consistent styling
+///
+/// # Parameters
+/// * `result` - The result text to display
+/// * `updates` - The output to write to
+/// * `is_error` - Whether this is an error message (changes formatting)
+/// * `use_bullet` - Whether to use a bullet point instead of a tick/exclamation
+pub fn queue_function_result(result: &str, updates: &mut impl Write, is_error: bool, use_bullet: bool) -> Result<()> {
+    use crossterm::queue;
+    use crossterm::style::{
+        self,
+        Color,
+    };
+
+    // Split the result into lines for proper formatting
+    let lines = result.lines().collect::<Vec<_>>();
+    let color = if is_error { Color::Red } else { Color::Reset };
+
+    queue!(updates, style::Print("\n"))?;
+
+    // Use appropriate symbol based on parameters
+    if let Some(first_line) = lines.first() {
+        // Select symbol: bullet for summaries, tick/exclamation for operations
+        let symbol = if is_error {
+            super::ERROR_EXCLAMATION
+        } else if use_bullet {
+            super::TOOL_BULLET
+        } else {
+            super::SUCCESS_TICK
+        };
+
+        // Set color to green for success ticks
+        let text_color = if is_error {
+            Color::Red
+        } else if !use_bullet {
+            Color::Green
+        } else {
+            Color::Reset
+        };
+
+        queue!(
+            updates,
+            style::SetForegroundColor(text_color),
+            style::Print(symbol),
+            style::ResetColor,
+            style::Print(first_line),
+            style::Print("\n"),
+        )?;
+    }
+
+    // For any additional lines, indent them properly
+    for line in lines.iter().skip(1) {
+        queue!(
+            updates,
+            style::Print("   "), // Same indentation as the bullet
+            style::SetForegroundColor(color),
+            style::Print(line),
+            style::ResetColor,
+            style::Print("\n"),
+        )?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::MAIN_SEPARATOR;

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -327,6 +327,7 @@ impl InvokeOutput {
             OutputKind::Text(s) => s.as_str(),
             OutputKind::Json(j) => j.as_str().unwrap_or_default(),
             OutputKind::Images(_) => "",
+            OutputKind::Mixed { text, .. } => text.as_str(), // Return the text part
         }
     }
 }
@@ -337,6 +338,7 @@ pub enum OutputKind {
     Text(String),
     Json(serde_json::Value),
     Images(RichImageBlocks),
+    Mixed { text: String, images: RichImageBlocks },
 }
 
 impl Default for OutputKind {

--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -48,41 +48,41 @@
                   "Search",
                   "Image"
                 ],
-                "description": "The operation mode"
+                "description": "The operation mode to run in: `Line`, `Directory`, `Search`. `Line` and `Search` are only for text files, and `Directory` is only for directories. `Image` is for image files, in this mode `image_paths` is required."
               },
               "path": {
                 "type": "string",
-                "description": "Path to file or directory (required for Line, Directory, Search modes)"
+                "description": "Path to the file or directory. The path should be absolute, or otherwise start with ~ for the user's home (required for Line, Directory, Search modes)."
               },
               "image_paths": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
-                "description": "Paths to images (required for Image mode)"
+                "description": "List of paths to the images. This is currently supported by the Image mode."
               },
               "start_line": {
                 "type": "integer",
-                "description": "Starting line number (optional for Line mode)",
+                "description": "Starting line number (optional, for Line mode). A negative index represents a line number starting from the end of the file.",
                 "default": 1
               },
               "end_line": {
                 "type": "integer",
-                "description": "Ending line number (optional for Line mode)",
+                "description": "Ending line number (optional, for Line mode). A negative index represents a line number starting from the end of the file.",
                 "default": -1
               },
               "pattern": {
                 "type": "string",
-                "description": "Search pattern (required for Search mode)"
+                "description": "Pattern to search for (required, for Search mode). Case insensitive. The pattern matching is performed per line."
               },
               "context_lines": {
                 "type": "integer",
-                "description": "Context lines around matches (optional for Search mode)",
+                "description": "Number of context lines around search results (optional, for Search mode)",
                 "default": 2
               },
               "depth": {
                 "type": "integer",
-                "description": "Directory traversal depth (optional for Directory mode)",
+                "description": "Depth of a recursive directory listing (optional, for Directory mode)",
                 "default": 0
               }
             },

--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -23,62 +23,83 @@
           "description": "A brief explanation of what the command does"
         }
       },
-      "required": ["command"]
+      "required": [
+        "command"
+      ]
     }
   },
   "fs_read": {
     "name": "fs_read",
-    "description": "Tool for reading files (for example, `cat -n`),  directories (for example, `ls -la`) and images. If user has supplied paths that appear to be leading to images, you should use this tool right away using Image mode. The behavior of this tool is determined by the `mode` parameter. The available modes are:\n- line: Show lines in a file, given by an optional `start_line` and optional `end_line`.\n- directory: List directory contents. Content is returned in the \"long format\" of ls (that is, `ls -la`).\n- search: Search for a pattern in a file. The pattern is a string. The matching is case insensitive.\n\nExample Usage:\n1. Read all lines from a file: command=\"line\", path=\"/path/to/file.txt\"\n2. Read the last 5 lines from a file: command=\"line\", path=\"/path/to/file.txt\", start_line=-5\n3. List the files in the home directory: command=\"line\", path=\"~\"\n4. Recursively list files in a directory to a max depth of 2: command=\"line\", path=\"/path/to/directory\", depth=2\n5. Search for all instances of \"test\" in a file: command=\"search\", path=\"/path/to/file.txt\", pattern=\"test\"\n",
+    "description": "Tool for reading files, directories and images. Always provide an 'operations' array.\n\nFor single operation: provide array with one element.\nFor batch operations: provide array with multiple elements.\n\nAvailable modes:\n- Line: Read lines from a file\n- Directory: List directory contents\n- Search: Search for patterns in files\n- Image: Read and process images\n\nExamples:\n1. Single: {\"operations\": [{\"mode\": \"Line\", \"path\": \"/file.txt\"}]}\n2. Batch: {\"operations\": [{\"mode\": \"Line\", \"path\": \"/file1.txt\"}, {\"mode\": \"Search\", \"path\": \"/file2.txt\", \"pattern\": \"test\"}]}",
     "input_schema": {
       "type": "object",
       "properties": {
-        "path": {
-          "description": "Path to the file or directory. The path should be absolute, or otherwise start with ~ for the user's home.",
-          "type": "string"
-        },
-        "image_paths": {
-          "description": "List of paths to the images. This is currently supported by the Image mode.",
+        "operations": {
           "type": "array",
+          "description": "Array of operations to execute. Provide one element for single operation, multiple for batch.",
           "items": {
-            "type": "string"
-          }
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "Line",
+                  "Directory",
+                  "Search",
+                  "Image"
+                ],
+                "description": "The operation mode"
+              },
+              "path": {
+                "type": "string",
+                "description": "Path to file or directory (required for Line, Directory, Search modes)"
+              },
+              "image_paths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Paths to images (required for Image mode)"
+              },
+              "start_line": {
+                "type": "integer",
+                "description": "Starting line number (optional for Line mode)",
+                "default": 1
+              },
+              "end_line": {
+                "type": "integer",
+                "description": "Ending line number (optional for Line mode)",
+                "default": -1
+              },
+              "pattern": {
+                "type": "string",
+                "description": "Search pattern (required for Search mode)"
+              },
+              "context_lines": {
+                "type": "integer",
+                "description": "Context lines around matches (optional for Search mode)",
+                "default": 2
+              },
+              "depth": {
+                "type": "integer",
+                "description": "Directory traversal depth (optional for Directory mode)",
+                "default": 0
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
+          "minItems": 1
         },
-        "mode": {
+        "summary": {
           "type": "string",
-          "enum": [
-            "Line",
-            "Directory",
-            "Search",
-            "Image"
-          ],
-          "description": "The mode to run in: `Line`, `Directory`, `Search`. `Line` and `Search` are only for text files, and `Directory` is only for directories. `Image` is for image files, in this mode `image_paths` is required."
-        },
-        "start_line": {
-          "type": "integer",
-          "description": "Starting line number (optional, for Line mode). A negative index represents a line number starting from the end of the file.",
-          "default": 1
-        },
-        "end_line": {
-          "type": "integer",
-          "description": "Ending line number (optional, for Line mode). A negative index represents a line number starting from the end of the file.",
-          "default": -1
-        },
-        "pattern": {
-          "type": "string",
-          "description": "Pattern to search for (required, for Search mode). Case insensitive. The pattern matching is performed per line."
-        },
-        "context_lines": {
-          "type": "integer",
-          "description": "Number of context lines around search results (optional, for Search mode)",
-          "default": 2
-        },
-        "depth": {
-          "type": "integer",
-          "description": "Depth of a recursive directory listing (optional, for Directory mode)",
-          "default": 0
+          "description": "Optional description of the purpose of this batch operation (mainly useful for multiple operations)"
         }
       },
-      "required": ["path", "mode"]
+      "required": [
+        "operations"
+      ]
     }
   },
   "fs_write": {
@@ -89,7 +110,12 @@
       "properties": {
         "command": {
           "type": "string",
-          "enum": ["create", "str_replace", "insert", "append"],
+          "enum": [
+            "create",
+            "str_replace",
+            "insert",
+            "append"
+          ],
           "description": "The commands to run. Allowed options are: `create`, `str_replace`, `insert`, `append`."
         },
         "file_text": {
@@ -117,7 +143,10 @@
           "type": "string"
         }
       },
-      "required": ["command", "path"]
+      "required": [
+        "command",
+        "path"
+      ]
     }
   },
   "use_aws": {
@@ -151,7 +180,12 @@
           "description": "Human readable description of the api that is being called."
         }
       },
-      "required": ["region", "service_name", "operation_name", "label"]
+      "required": [
+        "region",
+        "service_name",
+        "operation_name",
+        "label"
+      ]
     }
   },
   "gh_issue": {
@@ -177,7 +211,9 @@
           "description": "Optional: Previous user chat requests or steps that were taken that may have resulted in the issue or error response."
         }
       },
-      "required": ["title"]
+      "required": [
+        "title"
+      ]
     }
   },
   "thinking": {
@@ -191,46 +227,59 @@
           "description": "A reflective note or intermediate reasoning step such as \"The user needs to prepare their application for production. I need to complete three major asks including 1: building their code from source, 2: bundling their release artifacts together, and 3: signing the application bundle."
         }
       },
-      "required": ["thought"]
+      "required": [
+        "thought"
+      ]
     }
   },
   "knowledge": {
-      "name": "knowledge",
-      "description": "Store and retrieve information in knowledge base across chat sessions. Provides semantic search capabilities for files, directories, and text content.",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "command": {
-            "type": "string",
-            "enum": ["show", "add", "remove", "clear", "search", "update", "status", "cancel"],
-            "description": "The knowledge operation to perform:\n- 'show': List all knowledge contexts (no additional parameters required)\n- 'add': Add content to knowledge base (requires 'name' and 'value')\n- 'remove': Remove content from knowledge base (requires one of: 'name', 'context_id', or 'path')\n- 'clear': Remove all knowledge contexts.\n- 'search': Search across knowledge contexts (requires 'query', optional 'context_id')\n- 'update': Update existing context with new content (requires 'path' and one of: 'name', 'context_id')\n- 'status': Show background operation status and progress\n- 'cancel': Cancel background operations (optional 'operation_id' to cancel specific operation, or cancel all if not provided)"
-          },
-          "name": {
-            "type": "string",
-            "description": "A descriptive name for the knowledge context. Required for 'add' operations. Can be used for 'remove' and 'update' operations to identify the context."
-          },
-          "value": {
-            "type": "string",
-            "description": "The content to store in knowledge base. Required for 'add' operations. Can be either text content or a file/directory path. If it's a valid file or directory path, the content will be indexed; otherwise it's treated as text."
-          },
-          "context_id": {
-            "type": "string",
-            "description": "The unique context identifier for targeted operations. Can be obtained from 'show' command. Used for 'remove', 'update', and 'search' operations to specify which context to operate on."
-          },
-          "path": {
-            "type": "string",
-            "description": "File or directory path. Used in 'remove' operations to remove contexts by their source path, and required for 'update' operations to specify the new content location."
-          },
-          "query": {
-            "type": "string",
-            "description": "The search query string. Required for 'search' operations. Performs semantic search across knowledge contexts to find relevant content."
-          },
-          "operation_id": {
-            "type": "string",
-            "description": "Optional operation ID to cancel a specific operation. Used with 'cancel' command. If not provided, all active operations will be cancelled. Can be either the full operation ID or the short 8-character ID."
-          }
+    "name": "knowledge",
+    "description": "Store and retrieve information in knowledge base across chat sessions. Provides semantic search capabilities for files, directories, and text content.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "string",
+          "enum": [
+            "show",
+            "add",
+            "remove",
+            "clear",
+            "search",
+            "update",
+            "status",
+            "cancel"
+          ],
+          "description": "The knowledge operation to perform:\n- 'show': List all knowledge contexts (no additional parameters required)\n- 'add': Add content to knowledge base (requires 'name' and 'value')\n- 'remove': Remove content from knowledge base (requires one of: 'name', 'context_id', or 'path')\n- 'clear': Remove all knowledge contexts.\n- 'search': Search across knowledge contexts (requires 'query', optional 'context_id')\n- 'update': Update existing context with new content (requires 'path' and one of: 'name', 'context_id')\n- 'status': Show background operation status and progress\n- 'cancel': Cancel background operations (optional 'operation_id' to cancel specific operation, or cancel all if not provided)"
         },
-        "required": ["command"]
-      }
+        "name": {
+          "type": "string",
+          "description": "A descriptive name for the knowledge context. Required for 'add' operations. Can be used for 'remove' and 'update' operations to identify the context."
+        },
+        "value": {
+          "type": "string",
+          "description": "The content to store in knowledge base. Required for 'add' operations. Can be either text content or a file/directory path. If it's a valid file or directory path, the content will be indexed; otherwise it's treated as text."
+        },
+        "context_id": {
+          "type": "string",
+          "description": "The unique context identifier for targeted operations. Can be obtained from 'show' command. Used for 'remove', 'update', and 'search' operations to specify which context to operate on."
+        },
+        "path": {
+          "type": "string",
+          "description": "File or directory path. Used in 'remove' operations to remove contexts by their source path, and required for 'update' operations to specify the new content location."
+        },
+        "query": {
+          "type": "string",
+          "description": "The search query string. Required for 'search' operations. Performs semantic search across knowledge contexts to find relevant content."
+        },
+        "operation_id": {
+          "type": "string",
+          "description": "Optional operation ID to cancel a specific operation. Used with 'cancel' command. If not provided, all active operations will be cancelled. Can be either the full operation ID or the short 8-character ID."
+        }
+      },
+      "required": [
+        "command"
+      ]
+    }
   }
 }

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -608,10 +608,13 @@ fn qchat_path() -> Result<PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn qchat_path() -> Result<PathBuf> {
-    use fig_util::consts::CHAT_BINARY_NAME;
-    use macos_utils::bundle::get_bundle_path_for_executable;
+    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/chat_cli"))
 
-    Ok(get_bundle_path_for_executable(CHAT_BINARY_NAME).unwrap_or(home_local_bin()?.join(CHAT_BINARY_NAME)))
+    // use fig_util::consts::CHAT_BINARY_NAME;
+    // use macos_utils::bundle::get_bundle_path_for_executable;
+
+    // Ok(get_bundle_path_for_executable(CHAT_BINARY_NAME).unwrap_or(home_local_bin()?.
+    // join(CHAT_BINARY_NAME)))
 }
 
 #[cfg(test)]

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -608,13 +608,10 @@ fn qchat_path() -> Result<PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn qchat_path() -> Result<PathBuf> {
-    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/chat_cli"))
+    use fig_util::consts::CHAT_BINARY_NAME;
+    use macos_utils::bundle::get_bundle_path_for_executable;
 
-    // use fig_util::consts::CHAT_BINARY_NAME;
-    // use macos_utils::bundle::get_bundle_path_for_executable;
-
-    // Ok(get_bundle_path_for_executable(CHAT_BINARY_NAME).unwrap_or(home_local_bin()?.
-    // join(CHAT_BINARY_NAME)))
+    Ok(get_bundle_path_for_executable(CHAT_BINARY_NAME).unwrap_or(home_local_bin()?.join(CHAT_BINARY_NAME)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enhanced the `fs_read` tool to support batch operations, allowing multiple file/directory operations in a single command while maintaining backward compatibility.

### *Changes*
**1. Core Structure Updates:**
- Modified `FsRead` struct to support batch operations via operations: `Option<Vec<FsReadOperation>>`
- Added optional `summary` field for better UX when describing batch operations
- Maintained backward compatibility for single operations

**2. Mixed Output Support**
- Added `OutputKind::Mixed { text: String, images: RichImageBlocks }` variant to handle operations that return both text and images
- Ensures all operation results (text and images) are properly passed to the model
- Fixed issue where batch operations with images would lose text results

**3. `fs_read` JSON Schema Updates Updated** 
```
{
  "operations": [{
    "mode": "Line|Directory|Search|Image",
    "path": "...",
    // mode-specific parameters
  }],
  "purpose": "optional description"
}
```

### *Experience*

https://github.com/user-attachments/assets/457d98b1-3fae-401e-aff7-5411d3b495c8




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
