### PR TITLE
chore: rename --non-interactive back to --no-interactive, preserving alias for both

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -177,8 +177,8 @@ pub struct ChatArgs {
     #[arg(long, value_delimiter = ',', value_name = "TOOL_NAMES")]
     pub trust_tools: Option<Vec<String>>,
     /// Whether the command should run without expecting user input
-    #[arg(long, alias = "no-interactive")]
-    pub non_interactive: bool,
+    #[arg(long, alias = "non-interactive")]
+    pub no_interactive: bool,
     /// The first question to ask
     pub input: Option<String>,
 }
@@ -187,7 +187,7 @@ impl ChatArgs {
     pub async fn execute(self, os: &mut Os) -> Result<ExitCode> {
         let mut input = self.input;
 
-        if self.non_interactive && input.is_none() {
+        if self.no_interactive && input.is_none() {
             if !std::io::stdin().is_terminal() {
                 let mut buffer = String::new();
                 match std::io::stdin().read_to_string(&mut buffer) {
@@ -277,7 +277,7 @@ impl ChatArgs {
             .prompt_list_sender(prompt_response_sender)
             .prompt_list_receiver(prompt_request_receiver)
             .conversation_id(&conversation_id)
-            .build(os, Box::new(std::io::stderr()), !self.non_interactive)
+            .build(os, Box::new(std::io::stderr()), !self.no_interactive)
             .await?;
         let tool_config = tool_manager.load_tools(os, &mut stderr).await?;
         let mut tool_permissions = ToolPermissions::new(tool_config.len());
@@ -320,7 +320,7 @@ impl ChatArgs {
             model_id,
             tool_config,
             tool_permissions,
-            !self.non_interactive,
+            !self.no_interactive,
         )
         .await?
         .spawn(os)

--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -355,7 +355,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: false
+                no_interactive: false
             })),
             verbose: 2,
             help_all: false,
@@ -394,7 +394,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: false
+                no_interactive: false
             })
         );
     }
@@ -410,7 +410,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: false
+                no_interactive: false
             })
         );
     }
@@ -426,7 +426,7 @@ mod test {
                 model: None,
                 trust_all_tools: true,
                 trust_tools: None,
-                non_interactive: false
+                no_interactive: false
             })
         );
     }
@@ -442,7 +442,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: true
+                no_interactive: true
             })
         );
         assert_parse!(
@@ -454,7 +454,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: None,
-                non_interactive: true
+                no_interactive: true
             })
         );
     }
@@ -470,7 +470,7 @@ mod test {
                 model: None,
                 trust_all_tools: true,
                 trust_tools: None,
-                non_interactive: false
+                no_interactive: false
             })
         );
     }
@@ -486,7 +486,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: Some(vec!["".to_string()]),
-                non_interactive: false
+                no_interactive: false
             })
         );
     }
@@ -502,7 +502,7 @@ mod test {
                 model: None,
                 trust_all_tools: false,
                 trust_tools: Some(vec!["fs_read".to_string(), "fs_write".to_string()]),
-                non_interactive: false
+                no_interactive: false
             })
         );
     }


### PR DESCRIPTION
*Description of changes:*
- Making the default name for non-interactive mode back to `--no-interactive` for parity with previous versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
