### PR TITLE
fix: build script to specify the aws region when loading secrets

### DIFF
--- a/build-scripts/signing.py
+++ b/build-scripts/signing.py
@@ -298,7 +298,9 @@ def apple_notarize_file(file: pathlib.Path, signing_data: CdSigningData):
 
 def get_secretmanager_json(secret_id: str):
     info(f"Loading secretmanager value: {secret_id}")
-    secret_value = run_cmd_output(["aws", "secretsmanager", "get-secret-value", "--secret-id", secret_id])
+    secret_value = run_cmd_output(
+        ["aws", "--region", REGION, "secretsmanager", "get-secret-value", "--secret-id", secret_id]
+    )
     secret_string = json.loads(secret_value)["SecretString"]
     return json.loads(secret_string)
 


### PR DESCRIPTION
*Description of changes:*
- Updating the build script to specify the aws region when loading secrets. This is fine in CI due to a version difference with the installed aws CLI in CI, but fails when ran locally on a modern aws CLI version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
