### PR TITLE
fix: restore tool manager for the current session when /load conversation

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/persist.rs
+++ b/crates/chat-cli/src/cli/chat/cli/persist.rs
@@ -95,6 +95,7 @@ impl PersistSubcommand {
 
                 let mut new_state: ConversationState = tri!(serde_json::from_str(&contents), "import from", &path);
                 new_state.reload_serialized_state(os).await;
+                std::mem::swap(&mut new_state.tool_manager, &mut session.conversation.tool_manager);
                 session.conversation = new_state;
 
                 execute!(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When users run /load to restore a conversation, we should repopulate the ToolManager, since it is not serialized during /save.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
