### PR TITLE
[fix] Increments max size for directory.

### DIFF
--- a/crates/semantic_search_client/src/config.rs
+++ b/crates/semantic_search_client/src/config.rs
@@ -82,7 +82,7 @@ impl Default for SemanticSearchConfig {
             model_name: "all-MiniLM-L6-v2".to_string(),
             timeout: 30000, // 30 seconds
             base_dir: get_default_base_dir(),
-            max_files: 5000, // Default limit of 5000 files
+            max_files: 10000, // Default limit of 10000 files
         }
     }
 }
@@ -154,7 +154,7 @@ pub fn get_model_file_path(base_dir: &Path, model_name: &str, file_name: &str) -
 /// Result indicating success or failure
 pub fn ensure_models_dir(base_dir: &Path) -> std::io::Result<()> {
     let models_dir = get_models_dir(base_dir);
-    std::fs::create_dir_all(models_dir)
+    fs::create_dir_all(models_dir)
 }
 
 /// Initializes the global configuration.

--- a/crates/semantic_search_client/src/config.rs
+++ b/crates/semantic_search_client/src/config.rs
@@ -282,7 +282,7 @@ mod tests {
         assert_eq!(config.chunk_overlap, 128);
         assert_eq!(config.default_results, 5);
         assert_eq!(config.model_name, "all-MiniLM-L6-v2");
-        assert_eq!(config.max_files, 5000);
+        assert_eq!(config.max_files, 10000);
     }
 
     #[test]


### PR DESCRIPTION
fix(semantic-search): increase default max files limit and respect user config

- Increase default max_files from 5,000 to 10,000 to handle larger directories
- Ensure semantic search client respects user-modified configuration settings
- Refactor client initialization to load config from file instead of using defaults
- Remove unused config parameter from with_config_and_embedding_type method

This change allows users to process larger codebases and ensures their custom
configuration settings are properly applied when the semantic search client
initializes.