### PR TITLE
Implement enableMarkdown settings to allow users to disable markdown

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1658,7 +1658,7 @@ impl ChatSession {
         let mut offset = 0;
         let mut ended = false;
         let mut parser = ResponseParser::new(response);
-        let mut state = ParseState::new(Some(self.terminal_width()));
+        let mut state = ParseState::new(Some(self.terminal_width()), os.database.settings.get_bool(Setting::ChatEnableMarkdown));
         let mut response_prefix_printed = false;
 
         let mut tool_uses = Vec::new();
@@ -1688,10 +1688,13 @@ impl ChatSession {
                         },
                         parser::ResponseEvent::AssistantText(text) => {
                             // Add Q response prefix before the first assistant text.
-                            // This must be markdown - using a code tick, which is printed
-                            // as green.
                             if !response_prefix_printed && !text.trim().is_empty() {
-                                buf.push_str("`>` ");
+                                queue!(
+                                    self.stdout,
+                                    style::SetForegroundColor(Color::Green),
+                                    style::Print("> "),
+                                    style::SetForegroundColor(Color::Reset)
+                                )?;
                                 response_prefix_printed = true;
                             }
                             buf.push_str(&text);

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -33,6 +33,7 @@ pub enum Setting {
     McpNoInteractiveTimeout,
     McpLoadedBefore,
     ChatDefaultModel,
+    ChatEnableMarkdown,
 }
 
 impl AsRef<str> for Setting {
@@ -54,6 +55,7 @@ impl AsRef<str> for Setting {
             Self::McpNoInteractiveTimeout => "mcp.noInteractiveTimeout",
             Self::McpLoadedBefore => "mcp.loadedBefore",
             Self::ChatDefaultModel => "chat.defaultModel",
+            Self::ChatEnableMarkdown => "chat.enableMarkdown",
         }
     }
 }
@@ -85,6 +87,7 @@ impl TryFrom<&str> for Setting {
             "mcp.noInteractiveTimeout" => Ok(Self::McpNoInteractiveTimeout),
             "mcp.loadedBefore" => Ok(Self::McpLoadedBefore),
             "chat.defaultModel" => Ok(Self::ChatDefaultModel),
+            "chat.enableMarkdown" => Ok(Self::ChatEnableMarkdown),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }
@@ -204,12 +207,14 @@ mod test {
         assert_eq!(settings.get(Setting::ShareCodeWhispererContent), None);
         assert_eq!(settings.get(Setting::McpLoadedBefore), None);
         assert_eq!(settings.get(Setting::ChatDefaultModel), None);
+        assert_eq!(settings.get(Setting::ChatEnableMarkdown), None);
 
         settings.set(Setting::TelemetryEnabled, true).await.unwrap();
         settings.set(Setting::OldClientId, "test").await.unwrap();
         settings.set(Setting::ShareCodeWhispererContent, false).await.unwrap();
         settings.set(Setting::McpLoadedBefore, true).await.unwrap();
         settings.set(Setting::ChatDefaultModel, "model 1").await.unwrap();
+        settings.set(Setting::ChatEnableMarkdown, false).await.unwrap();
 
         assert_eq!(settings.get(Setting::TelemetryEnabled), Some(&Value::Bool(true)));
         assert_eq!(
@@ -225,15 +230,18 @@ mod test {
             settings.get(Setting::ChatDefaultModel),
             Some(&Value::String("model 1".to_string()))
         );
+        assert_eq!(settings.get(Setting::ChatEnableMarkdown), Some(&Value::Bool(false)));
 
         settings.remove(Setting::TelemetryEnabled).await.unwrap();
         settings.remove(Setting::OldClientId).await.unwrap();
         settings.remove(Setting::ShareCodeWhispererContent).await.unwrap();
         settings.remove(Setting::McpLoadedBefore).await.unwrap();
+        settings.remove(Setting::ChatEnableMarkdown).await.unwrap();
 
         assert_eq!(settings.get(Setting::TelemetryEnabled), None);
         assert_eq!(settings.get(Setting::OldClientId), None);
         assert_eq!(settings.get(Setting::ShareCodeWhispererContent), None);
         assert_eq!(settings.get(Setting::McpLoadedBefore), None);
+        assert_eq!(settings.get(Setting::ChatEnableMarkdown), None);
     }
 }


### PR DESCRIPTION
*Issue #, if available:* 
- None.

*Why make this change:*
- This was personally bothering me as a user - asking Q to generate markdown-formatted text (e.g. CR descriptions) would result in rendered markdown. I would have to re-format the output after pasting it into CRUX.

*Description of changes:*
- Created a new `chat` setting, `enableMarkdown`, that users can use to disable markdown rendering in the responses. The setting defaults to `true`, unless specified `false` by the user.
- When the `enableMarkdown` setting is set to `false`, skip the markdown-related parsers in `parse.rs`.
- Added unit tests to validate behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
