### PR TITLE
chore: bump version to 1.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "bitflags 2.9.1",
  "camino",
@@ -279,7 +279,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "bindgen 0.71.1",
  "objc",
@@ -1610,7 +1610,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chat_cli"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2369,7 +2369,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dbus"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "async-trait",
  "clap",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "anstream",
  "async-trait",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "cfg-if",
  "clap",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "apple-bundle",
  "fig_ipc",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "fig_util",
  "parking_lot",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "cfg-if",
  "dirs 5.0.1",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "fd-lock",
  "fig_util",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry-client",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry-client",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_utils"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "bytes",
  "fig_os_shim",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -7687,7 +7687,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -8724,7 +8724,7 @@ dependencies = [
 
 [[package]]
 name = "semantic_search_client"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "anyhow",
  "bm25",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 edition = "2024"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.12.3"
+version = "1.12.4"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -12,6 +12,22 @@
     },
     {
       "type": "release",
+      "date": "2025-07-08",
+      "version": "1.12.4",
+      "title": "Version 1.12.4",
+      "changes": [
+        {
+          "type": "added",
+          "description": "Extra options for history compaction - see `/compact --help` - [#402](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/402)"
+        },
+        {
+          "type": "fixed",
+          "description": "Issues with `/compact`"
+        }
+      ]
+    },
+    {
+      "type": "release",
       "date": "2025-07-03",
       "version": "1.12.3",
       "title": "Version 1.12.3",


### PR DESCRIPTION
*Description of changes:*
- Bumping the version to v1.12.4 and adding feed.json entries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
