### PR TITLE
fix: more issues with /compact

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -12,17 +12,17 @@
     },
     {
       "type": "release",
-      "date": "2025-07-08",
+      "date": "2025-07-09",
       "version": "1.12.4",
       "title": "Version 1.12.4",
       "changes": [
         {
           "type": "added",
-          "description": "Extra options for history compaction - see `/compact --help` - [#402](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/402)"
+          "description": "Extra options for history compaction in `q chat` - see `/compact --help` - [#402](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/402)"
         },
         {
           "type": "fixed",
-          "description": "Issues with `/compact`"
+          "description": "Issues with `/compact` - [#407](https://github.com/aws/amazon-q-developer-cli-autocomplete/pull/407)"
         }
       ]
     },


### PR DESCRIPTION
*Description of changes:*
Addressing issues not caught by #402 
- Moving the conversation invariant code into a shared function across the normal request flow and the compact flow.
- Adding a new conversation invariant check for when the next user message contains tool use results, but the last assistant message does not contain a corresponding tool use. This is encountered in the current `/compact` implementation as an unhandled edge case
- Not sending the complete tool spec as part of the compact request
- Including the current summary as context for the compact request, if available.
- Changing the compaction algorithm to instead only truncate if `history.len() <= 2` (ie, the history includes at most 2 user/assistant message pairs). This is done because it's almost always the case that the first message is the initial user prompt, and the second message is a large result that overflows the context window.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
