### PR TITLE
fix: deserialize builder id token correctly when it is saved by the qchat binary

### DIFF
--- a/crates/fig_auth/src/builder_id.rs
+++ b/crates/fig_auth/src/builder_id.rs
@@ -72,6 +72,7 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum OAuthFlow {
     DeviceCode,
+    #[serde(alias = "Pkce")]
     PKCE,
 }
 
@@ -647,6 +648,7 @@ mod tests {
     fn test_oauth_flow_ser_deser() {
         test_ser_deser!(OAuthFlow, OAuthFlow::DeviceCode, "DeviceCode");
         test_ser_deser!(OAuthFlow, OAuthFlow::PKCE, "PKCE");
+        assert_eq!(OAuthFlow::PKCE, serde_json::from_str("\"Pkce\"").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
*Description of changes:*
- The `qchat` binary serializes the OAuth flow as `"Pkce"` but the `q` binary only recognizes `"PKCE"`. This causes authentication to fail if the user has a qchat session open for longer than an hour, and the `qchat` binary ends up refreshing the token.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
