### PR TITLE
feat: Adding boolean setting for history hints

### DIFF
--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -34,6 +34,7 @@ pub enum Setting {
     McpLoadedBefore,
     ChatDefaultModel,
     ChatDisableAutoCompaction,
+    ChatEnableHistoryHints,
 }
 
 impl AsRef<str> for Setting {
@@ -56,6 +57,7 @@ impl AsRef<str> for Setting {
             Self::McpLoadedBefore => "mcp.loadedBefore",
             Self::ChatDefaultModel => "chat.defaultModel",
             Self::ChatDisableAutoCompaction => "chat.disableAutoCompaction",
+            Self::ChatEnableHistoryHints => "chat.enableHistoryHints",
         }
     }
 }
@@ -88,6 +90,7 @@ impl TryFrom<&str> for Setting {
             "mcp.loadedBefore" => Ok(Self::McpLoadedBefore),
             "chat.defaultModel" => Ok(Self::ChatDefaultModel),
             "chat.disableAutoCompaction" => Ok(Self::ChatDisableAutoCompaction),
+            "chat.enableHistoryHints" => Ok(Self::ChatEnableHistoryHints),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }


### PR DESCRIPTION
Adding boolean setting for history hints. If the settings is not set, it's taken as false by default.

```
q settings chat.enableHistoryHints true
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
