### PR TITLE
feat(telemetry): add client application and additional info from tool

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -129,6 +129,15 @@ impl Tool {
             Tool::Thinking(think) => think.validate(os).await,
         }
     }
+
+    /// Returns additional information about the tool if available
+    pub fn get_additional_info(&self) -> Option<serde_json::Value> {
+        match self {
+            Tool::UseAws(use_aws) => Some(use_aws.get_additional_info()),
+            // Add other tool types here as they implement get_additional_info()
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -173,6 +173,13 @@ impl UseAws {
         Ok(())
     }
 
+    pub fn get_additional_info(&self) -> serde_json::Value {
+        serde_json::json!({
+            "aws_service_name": self.service_name.clone(),
+            "aws_operation_name": self.operation_name.clone()
+        })
+    }
+
     /// Returns the CLI arguments properly formatted as kebab case if parameters is
     /// [Option::Some], otherwise None
     fn cli_parameters(&self) -> Option<Vec<(String, String)>> {

--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -137,7 +137,10 @@ impl RootSubcommand {
 
         // Send executed telemetry.
         if self.valid_for_telemetry() {
-            os.telemetry.send_cli_subcommand_executed(&self).ok();
+            os.telemetry
+                .send_cli_subcommand_executed(&os.database, &self)
+                .await
+                .ok();
         }
 
         match self {

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -42,6 +42,7 @@ pub struct Event {
     pub created_time: Option<SystemTime>,
     pub credential_start_url: Option<String>,
     pub sso_region: Option<String>,
+    pub client_application: Option<String>,
     #[serde(flatten)]
     pub ty: EventType,
 }
@@ -53,6 +54,7 @@ impl Event {
             created_time: Some(SystemTime::now()),
             credential_start_url: None,
             sso_region: None,
+            client_application: None,
         }
     }
 
@@ -62,6 +64,10 @@ impl Event {
 
     pub fn set_sso_region(&mut self, sso_region: String) {
         self.sso_region = Some(sso_region);
+    }
+
+    pub fn set_client_application(&mut self, client_application: String) {
+        self.client_application = Some(client_application);
     }
 
     pub fn into_metric_datum(self) -> Option<MetricDatum> {
@@ -100,6 +106,7 @@ impl Event {
                     credential_start_url: self.credential_start_url.map(Into::into),
                     codewhispererterminal_subcommand: Some(subcommand.into()),
                     codewhispererterminal_in_cloudshell: None,
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -152,6 +159,7 @@ impl Event {
                     reason_desc: reason_desc.map(Into::into),
                     status_code: status_code.map(|v| v as i64).map(Into::into),
                     codewhispererterminal_model: model.map(Into::into),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -169,6 +177,8 @@ impl Event {
                 output_token_size,
                 custom_tool_call_latency,
                 model,
+                aws_service_name,
+                aws_operation_name,
             } => Some(
                 CodewhispererterminalToolUseSuggested {
                     create_time: self.created_time,
@@ -190,6 +200,9 @@ impl Event {
                     codewhispererterminal_custom_tool_latency: custom_tool_call_latency
                         .map(|l| CodewhispererterminalCustomToolLatency(l as i64)),
                     codewhispererterminal_model: model.map(Into::into),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
+                    codewhispererterminal_aws_service_name: aws_service_name.map(Into::into),
+                    codewhispererterminal_aws_operation_name: aws_operation_name.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -208,6 +221,7 @@ impl Event {
                     codewhispererterminal_tools_per_mcp_server: Some(CodewhispererterminalToolsPerMcpServer(
                         number_of_tools as i64,
                     )),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -266,6 +280,7 @@ impl Event {
                     reason: reason.map(Into::into),
                     reason_desc: reason_desc.map(Into::into),
                     status_code: status_code.map(|v| v as i64).map(Into::into),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -320,6 +335,8 @@ pub enum EventType {
         output_token_size: Option<usize>,
         custom_tool_call_latency: Option<usize>,
         model: Option<String>,
+        aws_service_name: Option<String>,
+        aws_operation_name: Option<String>,
     },
     McpServerInit {
         conversation_id: String,
@@ -364,6 +381,8 @@ pub struct ToolUseEventBuilder {
     pub output_token_size: Option<usize>,
     pub custom_tool_call_latency: Option<usize>,
     pub model: Option<String>,
+    pub aws_service_name: Option<String>,
+    pub aws_operation_name: Option<String>,
 }
 
 impl ToolUseEventBuilder {
@@ -382,6 +401,8 @@ impl ToolUseEventBuilder {
             output_token_size: None,
             custom_tool_call_latency: None,
             model,
+            aws_service_name: None,
+            aws_operation_name: None,
         }
     }
 

--- a/crates/chat-cli/src/telemetry/definitions.rs
+++ b/crates/chat-cli/src/telemetry/definitions.rs
@@ -32,6 +32,7 @@ mod tests {
             reason_desc: None,
             status_code: None,
             codewhispererterminal_model: None,
+            codewhispererterminal_client_application: None,
         });
 
         let s = serde_json::to_string_pretty(&metric_datum_init).unwrap();

--- a/crates/chat-cli/src/util/consts.rs
+++ b/crates/chat-cli/src/util/consts.rs
@@ -64,7 +64,10 @@ pub mod env_var {
         Q_USING_ZSH_AUTOSUGGESTIONS = "Q_USING_ZSH_AUTOSUGGESTIONS",
 
         /// Overrides the path to the bundle metadata released with certain desktop builds.
-        Q_BUNDLE_METADATA_PATH = "Q_BUNDLE_METADATA_PATH"
+        Q_BUNDLE_METADATA_PATH = "Q_BUNDLE_METADATA_PATH",
+
+        /// Identifier for the client application or service using the chat-cli
+        Q_CLI_CLIENT_APPLICATION = "Q_CLI_CLIENT_APPLICATION"
     }
 }
 

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -86,6 +86,16 @@
       "description": "The name associated with a tool"
     },
     {
+      "name": "codewhispererterminal_AwsServiceName",
+      "type": "string",
+      "description": "AWS service called by the tool"
+    },
+    {
+      "name": "codewhispererterminal_AwsOperationName",
+      "type": "string",
+      "description": "Specific operation of the AWS service invoked by the tool"
+    },
+    {
       "name": "codewhispererterminal_isToolUseAccepted",
       "type": "boolean",
       "description": "Denotes if a tool use event has been fulfilled"
@@ -149,6 +159,11 @@
       "name": "codewhispererterminal_model",
       "type": "string",
       "description": "The underlying LLM used by the service, set by the client"
+    },
+    {
+      "name": "codewhispererterminal_clientApplication",
+      "type": "string",
+      "description": "Identifier for the client application or service using the chat-cli"
     }
   ],
   "metrics": [
@@ -177,7 +192,8 @@
         { "type": "reason", "required": false },
         { "type": "reasonDesc", "required": false },
         { "type": "statusCode", "required": false },
-        { "type": "codewhispererterminal_model" }
+        { "type": "codewhispererterminal_model" },
+        { "type": "codewhispererterminal_clientApplication" }
       ]
     },
     {
@@ -219,7 +235,8 @@
       "metadata": [
         { "type": "credentialStartUrl" },
         { "type": "codewhispererterminal_subcommand" },
-        { "type": "codewhispererterminal_inCloudshell" }
+        { "type": "codewhispererterminal_inCloudshell" },
+        { "type": "codewhispererterminal_clientApplication" }
       ]
     },
     {
@@ -246,7 +263,10 @@
           "required": false
         },
         { "type": "codewhispererterminal_customToolLatency", "required": false },
-        { "type": "codewhispererterminal_model" }
+        { "type": "codewhispererterminal_model" },
+        { "type": "codewhispererterminal_clientApplication" },
+        { "type": "codewhispererterminal_AwsServiceName", "required": false },
+        { "type": "codewhispererterminal_AwsOperationName", "required": false }
       ]
     },
     {
@@ -260,7 +280,8 @@
           "type": "codewhispererterminal_mcpServerInitFailureReason",
           "required": false
         },
-        { "type": "codewhispererterminal_toolsPerMcpServer" }
+        { "type": "codewhispererterminal_toolsPerMcpServer" },
+        { "type": "codewhispererterminal_clientApplication" }
       ]
     },
     {
@@ -299,7 +320,8 @@
           { "type": "result" },
           { "type": "reason", "required": false },
           { "type": "reasonDesc", "required": false },
-          { "type": "statusCode", "required": false }
+          { "type": "statusCode", "required": false },
+          { "type": "codewhispererterminal_clientApplication" }
       ]
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*

1. New metric referring the client application using the Q CLI
 - Use `Q_CLI_CLIENT_APPLICATION` environment variable to set this field
 - Telemetry events supporting this new metric:
    * ChatAddedMessage
    * CliSubcommandExecuted
    * ToolUseSuggested
    * McpServerInit
    * MessageResponseError

2. Additional information about the tool being used
 - Example for `use_aws` tool: `aws_service_name` and `aws_operation_name`
 - Any tool can leverage this metric in future if needed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
