### PR TITLE
fix: execute bash perms for potential unwanted execution

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -81,10 +81,18 @@ impl ExecuteCommand {
                 // against unwanted mutations
                 Some(cmd)
                     if cmd == "find"
-                        && cmd_args
-                            .iter()
-                            .any(|arg| arg.contains("-exec") || arg.contains("-delete")) =>
+                        && cmd_args.iter().any(|arg| {
+                            arg.contains("-exec") // includes -execdir
+                                || arg.contains("-delete")
+                                || arg.contains("-ok") // includes -okdir
+                        }) =>
                 {
+                    return true;
+                },
+                // Special casing for `grep`. -P flag for perl regexp has RCE issues, apparently
+                // should not be supported within grep but is flagged as a possibility since this is perl
+                // regexp.
+                Some(cmd) if cmd == "grep" && cmd_args.iter().any(|arg| arg.contains("-P")) => {
                     return true;
                 },
                 Some(cmd) if !READONLY_COMMANDS.contains(&cmd.as_str()) => return true,
@@ -161,6 +169,66 @@ pub fn format_output(output: &str, max_size: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_requires_acceptance_for_readonly_commands() {
+        let cmds = &[
+            // Safe commands
+            ("ls ~", false),
+            ("ls -al ~", false),
+            ("pwd", false),
+            ("echo 'Hello, world!'", false),
+            ("which aws", false),
+            // Potentially dangerous readonly commands
+            ("echo hi > myimportantfile", true),
+            ("ls -al >myimportantfile", true),
+            ("echo hi 2> myimportantfile", true),
+            ("echo hi >> myimportantfile", true),
+            ("echo $(rm myimportantfile)", true),
+            ("echo `rm myimportantfile`", true),
+            ("echo hello && rm myimportantfile", true),
+            ("echo hello&&rm myimportantfile", true),
+            ("ls nonexistantpath || rm myimportantfile", true),
+            ("echo myimportantfile | xargs rm", true),
+            ("echo myimportantfile|args rm", true),
+            ("echo <(rm myimportantfile)", true),
+            ("cat <<< 'some string here' > myimportantfile", true),
+            ("echo '\n#!/usr/bin/env bash\necho hello\n' > myscript.sh", true),
+            ("cat <<EOF > myimportantfile\nhello world\nEOF", true),
+            // Safe piped commands
+            ("find . -name '*.rs' | grep main", false),
+            ("ls -la | grep .git", false),
+            ("cat file.txt | grep pattern | head -n 5", false),
+            // Unsafe piped commands
+            ("find . -name '*.rs' | rm", true),
+            ("ls -la | grep .git | rm -rf", true),
+            ("echo hello | sudo rm -rf /", true),
+            // `find` command arguments
+            ("find important-dir/ -exec rm {} \\;", true),
+            ("find . -name '*.c' -execdir gcc -o '{}.out' '{}' \\;", true),
+            ("find important-dir/ -delete", true),
+            (
+                "echo y | find . -type f -maxdepth 1 -okdir open -a Calculator {} +",
+                true,
+            ),
+            ("find important-dir/ -name '*.txt'", false),
+            // `grep` command arguments
+            ("echo 'test data' | grep -P '(?{system(\"date\")})'", true),
+        ];
+        for (cmd, expected) in cmds {
+            let tool = serde_json::from_value::<ExecuteCommand>(serde_json::json!({
+                "command": cmd,
+            }))
+            .unwrap();
+            assert_eq!(
+                tool.requires_acceptance(),
+                *expected,
+                "expected command: `{}` to have requires_acceptance: `{}`",
+                cmd,
+                expected
+            );
+        }
+    }
 
     #[test]
     fn test_requires_acceptance_for_windows_commands() {


### PR DESCRIPTION
*Description of changes:*
- Adding `-ok` checking for readonly checks on `find`, since it can be used to execute arbitrary code. Example: `echo y | find . -type f -maxdepth 1 -okdir open -a Calculator {} +`
- Adding `-P` for grep, since perl regexp can have similar code execution with `(?{..})` syntax. This doesn't seem to be implemented with grep, but since it's possible with perl regexp's and is marked as experimental in `man grep`, adding it here for safety.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
