### PR TITLE
fix: formatting hooks to enable correct caching with the API

### DIFF
--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -117,7 +117,7 @@ rustyline = { version = "15.0.0", features = [
 semantic_search_client = { path = "../semantic_search_client" }
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = "1.0.140"
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
 sha2 = "0.10.9"
 shell-color = "1.0.0"
 shell-words = "1.1.0"

--- a/crates/chat-cli/src/cli/chat/cli/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/cli/hooks.rs
@@ -873,8 +873,14 @@ mod tests {
         manager.add_hook(&os, "hook2".to_string(), hook2, false).await?;
 
         // Run the hooks
-        let results = manager.run_hooks(&mut vec![]).await.unwrap();
-        assert_eq!(results.len(), 2); // Should include both hooks
+        let results = manager
+            .run_hooks(HookTrigger::ConversationStart, &mut vec![])
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+
+        let results = manager.run_hooks(HookTrigger::PerPrompt, &mut vec![]).await.unwrap();
+        assert_eq!(results.len(), 0);
 
         Ok(())
     }
@@ -889,14 +895,20 @@ mod tests {
         manager.add_hook(&os, "profile_hook".to_string(), hook1, false).await?;
         manager.add_hook(&os, "global_hook".to_string(), hook2, true).await?;
 
-        let results = manager.run_hooks(&mut vec![]).await.unwrap();
+        let results = manager
+            .run_hooks(HookTrigger::ConversationStart, &mut vec![])
+            .await
+            .unwrap();
         assert_eq!(results.len(), 2); // Should include both hooks
 
         // Create and switch to a new profile
         manager.create_profile(&os, "test_profile").await?;
         manager.switch_profile(&os, "test_profile").await?;
 
-        let results = manager.run_hooks(&mut vec![]).await.unwrap();
+        let results = manager
+            .run_hooks(HookTrigger::ConversationStart, &mut vec![])
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1); // Should include global hook
         assert_eq!(results[0].0.name, "global_hook");
 


### PR DESCRIPTION
*Description of changes:*
- Updating the conversation hooks to be consistent across user messages and tool use results, which enables prompt caching by the backend. Now, we will *always* include conversation start hooks in every request (other than `/compact`).
- Adding `preserve_order` to `serde_json` since the ordering for maps is otherwise nondeterministic. This is required for prompt caching (reasoning: large tool specs -> higher chance for nondeterministic key reordering across requests -> cache misses)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
