### PR TITLE
fixes inability to write non valid utf8 characters

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -104,7 +104,7 @@ impl FsWrite {
                 path, old_str, new_str, ..
             } => {
                 let path = sanitize_path_tool_arg(os, path);
-                let file = os.fs.read_to_string(&path).await?;
+                let file = os.fs.read_to_string_lossy(&path).await?;
                 let matches = file.match_indices(old_str).collect::<Vec<_>>();
                 queue!(
                     output,
@@ -131,7 +131,7 @@ impl FsWrite {
                 ..
             } => {
                 let path = sanitize_path_tool_arg(os, path);
-                let mut file = os.fs.read_to_string(&path).await?;
+                let mut file = os.fs.read_to_string_lossy(&path).await?;
                 queue!(
                     output,
                     style::Print("Updating: "),
@@ -165,7 +165,7 @@ impl FsWrite {
                     style::Print("\n"),
                 )?;
 
-                let mut file = os.fs.read_to_string(&path).await?;
+                let mut file = os.fs.read_to_string_lossy(&path).await?;
                 if !file.ends_with_newline() {
                     file.push('\n');
                 }
@@ -185,7 +185,7 @@ impl FsWrite {
                 let path = sanitize_path_tool_arg(os, path);
                 let relative_path = format_path(cwd, &path);
                 let prev = if os.fs.exists(&path) {
-                    let file = os.fs.read_to_string_sync(&path)?;
+                    let file = os.fs.read_to_string_lossy_sync(&path)?;
                     stylize_output_if_able(os, &path, &file)
                 } else {
                     Default::default()
@@ -206,7 +206,7 @@ impl FsWrite {
             } => {
                 let path = sanitize_path_tool_arg(os, path);
                 let relative_path = format_path(cwd, &path);
-                let file = os.fs.read_to_string_sync(&path)?;
+                let file = os.fs.read_to_string_lossy_sync(&path)?;
 
                 // Diff the old with the new by adding extra context around the line being inserted
                 // at.
@@ -232,7 +232,7 @@ impl FsWrite {
             } => {
                 let path = sanitize_path_tool_arg(os, path);
                 let relative_path = format_path(cwd, &path);
-                let file = os.fs.read_to_string_sync(&path)?;
+                let file = os.fs.read_to_string_lossy_sync(&path)?;
                 let (start_line, _) = match line_number_at(&file, old_str) {
                     Some((start_line, end_line)) => (start_line, end_line),
                     _ => (0, 0),
@@ -249,7 +249,7 @@ impl FsWrite {
             FsWrite::Append { path, new_str, .. } => {
                 let path = sanitize_path_tool_arg(os, path);
                 let relative_path = format_path(cwd, &path);
-                let start_line = os.fs.read_to_string_sync(&path)?.lines().count() + 1;
+                let start_line = os.fs.read_to_string_lossy_sync(&path)?.lines().count() + 1;
                 let file = stylize_output_if_able(os, &relative_path, new_str);
                 print_diff(output, &Default::default(), &file, start_line)?;
 


### PR DESCRIPTION
*Issue #, if available:*
Internal ticket. Summary is as follows: 
```
Operating System: MacOS
CLI Version: 1.12.6
Bug description: 

Reading a file, then asking for a fix, Q CLI is unable to write the fix.
fs_write invalidate UTF-8 in stream

Repro Steps: 
Read applescript file (fs_read is successfull)
Ask for it to find a particular bug
fs_write gives error:

🛠️  Using tool: fs_write
 ⋮
 ● Path: outlook.applescript

Amazon Q is having trouble responding right now:
   0: failed to print tool, `fs_write`: stream did not contain valid UTF-8

Location:
   crates/chat-cli/src/cli/chat/mod.rs:893

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.

Please attach screenshots/videos/details to the ticket as would be possible.

Debug Logs and file that is being modified attached.
Note - asking Q to display what it would change in the files is successfull.
```

*Description of changes:*
- Uses lossy conversion from bytes to string for fs_write. 
- This was already the case for fs_read (hence q cli had no trouble reading the problematic file mentioned in the ticket).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.