### PR TITLE
fixes inability to untrust read only tools

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1605,8 +1605,8 @@ impl ChatSession {
 
             // If there is an override, we will use it. Otherwise fall back to Tool's default.
             let allowed = self.tool_permissions.trust_all
-                || (self.tool_permissions.has(&tool.name) && self.tool_permissions.is_trusted(&tool.name))
-                || !tool.tool.requires_acceptance(os);
+                || self.tool_permissions.is_trusted(&tool.name)
+                || (!self.tool_permissions.has(&tool.name) && !tool.tool.requires_acceptance(os));
 
             if os
                 .database


### PR DESCRIPTION
*Issue #, if available:*
Internal issue. Summary as below: 
The Amazon Q CLI has incorrectly escalated permissions for the execute_bash tool without my consent, allowing it to execute a shell command without ever having been granted approval, which was not the expected or desired behavior.

Example: 
```bash
> /tools


Tool                                                    Permission
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔Built-in:
- execute_bash                                          * trust read-only commands
- fs_read                                               * trusted
- fs_write                                              * not trusted
- report_issue                                          * trusted
- use_aws                                               * trust read-only commands

Trusted tools will run without confirmation.
* Default settings

💡 Use /tools help to edit permissions.


> /tools untrust fs_read

Tool 'fs_read' is set to per-request confirmation.

> /tools


Tool                                                     Permission
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔Built-in:
- execute_bash                                           * trust read-only commands
- fs_read                                                  not trusted
- fs_write                                               * not trusted
- report_issue                                           * trusted
- use_aws                                                * trust read-only commands

Trusted tools will run without confirmation.
* Default settings

💡 Use /tools help to edit permissions.


> use fs_read to list files in ~/


> I'll help you list the files in your home directory using the fs_read tool.


🛠️  Using tool: fs_read (trusted)
 ⋮
 ● Reading directory: ~ with maximum depth of 0
 ⋮
 ● Completed in 0.6s


> Here's a listing of the files and directories in your home directory (~). You
have a mix of:

1. Configuration directories (like .aws, .config, .ssh)
2. Project directories (like projects, repos, cdk, terraform)
3. Application data directories (like .vscode, .iterm2)
4. Standard macOS directories (like Desktop, Documents, Downloads, Pictures)
5. Various configuration files (like .zshrc, .bashrc, .gitconfig)

There are also several development-related directories like IdeaProjects,
PycharmProjects, and GolandProjects that suggest you work with different
programming environments.
```

*Description of changes:*
- Adds check to ensure tool is absent from tool settings before evaluating if it requires permission

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
