### PR TITLE
Revert "Revert "feat(agent): adds root command for chat's agent root command (#431)" (#443)"

### DIFF
--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -218,6 +218,13 @@ pub enum CliRootCommands {
     /// Inline shell completions
     #[command(subcommand)]
     Inline(inline::InlineSubcommand),
+    /// Agent root commands
+    #[command(disable_help_flag = true)]
+    Agent {
+        /// Args for Agent subcommand
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 impl CliRootCommands {
@@ -252,6 +259,7 @@ impl CliRootCommands {
             CliRootCommands::Chat { .. } => "chat",
             CliRootCommands::Mcp { .. } => "mcp",
             CliRootCommands::Inline(_) => "inline",
+            CliRootCommands::Agent { .. } => "agent",
         }
     }
 }
@@ -375,6 +383,13 @@ impl Cli {
                     Self::execute_chat("mcp", Some(args), true).await
                 },
                 CliRootCommands::Inline(subcommand) => subcommand.execute(&cli_context).await,
+                CliRootCommands::Agent { args } => {
+                    if args.iter().any(|arg| ["--help", "-h"].contains(&arg.as_str())) {
+                        return Self::execute_chat("agent", Some(args), false).await;
+                    }
+
+                    Self::execute_chat("agent", Some(args), true).await
+                },
             },
             // Root command
             None => Self::execute_chat("chat", None, true).await,


### PR DESCRIPTION
This reverts commit 4572eec47624f3fe6aecdb4782791d5b2832631b.

#443 originally reverted #431 due to a release, so this PR is adding it back.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
