### PR TITLE
feat(cli): skip prompts when identity provider and region CLI args are provided (issue #654)

### DIFF
--- a/crates/chat-cli/src/cli/user.rs
+++ b/crates/chat-cli/src/cli/user.rs
@@ -108,17 +108,22 @@ impl LoginArgs {
                 let (start_url, region) = match login_method {
                     AuthMethod::BuilderId => (None, None),
                     AuthMethod::IdentityCenter => {
-                        let default_start_url = match self.identity_provider {
-                            Some(start_url) => Some(start_url),
-                            None => os.database.get_start_url()?,
+                        let start_url = match self.identity_provider {
+                            Some(url) => url, // CLI arg provided - use directly
+                            None => {
+                                // No CLI arg - prompt with settings default
+                                let default = os.database.get_start_url()?;
+                                input("Enter Start URL", default.as_deref())?
+                            },
                         };
-                        let default_region = match self.region {
-                            Some(region) => Some(region),
-                            None => os.database.get_idc_region()?,
+                        let region = match self.region {
+                            Some(r) => r, // CLI arg provided - use directly
+                            None => {
+                                // No CLI arg - prompt with settings default
+                                let default = os.database.get_idc_region()?;
+                                input("Enter Region", default.as_deref())?
+                            },
                         };
-
-                        let start_url = input("Enter Start URL", default_start_url.as_deref())?;
-                        let region = input("Enter Region", default_region.as_deref())?;
 
                         let _ = os.database.set_start_url(start_url.clone());
                         let _ = os.database.set_idc_region(region.clone());


### PR DESCRIPTION
Allow non-interactive login when --identity-provider and --region are specified via CLI arguments. This enables automation and scripting scenarios without requiring user confirmation.

Parallel to https://github.com/aws/amazon-q-developer-cli/pull/2660 addressing issue #2659.

*Issue #, if available:* #654

*Description of changes:* Changes to user.rs to check if identity provider and region are supplied as CLI arguments; if so, use them; if not, prompt the user (with default values if available)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
