### PR TITLE
feat: bump version to 1.17.0 and update feed.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "bitflags 2.9.1",
  "camino",
@@ -279,7 +279,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "bindgen 0.71.1",
  "objc",
@@ -1630,7 +1630,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chat_cli"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2389,7 +2389,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dbus"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "anstream",
  "async-trait",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "cfg-if",
  "clap",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "apple-bundle",
  "fig_ipc",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "fig_util",
  "parking_lot",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "cfg-if",
  "dirs 5.0.1",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "fd-lock",
  "fig_util",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry-client",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry-client",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_utils"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "bytes",
  "fig_os_shim",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -7718,7 +7718,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "semantic_search_client"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "bm25",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 edition = "2024"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.16.3"
+version = "1.17.0"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -12,10 +12,22 @@
     },
     {
       "type": "release",
-      "date": "2025-09-26",
-      "version": "1.16.3",
-      "title": "Version 1.16.3",
+      "date": "2025-09-29",
+      "version": "1.17.0",
+      "title": "Version 1.17.0",
       "changes": [
+        {
+          "type": "added",
+          "description": "SSE support for MCP - [#2995](https://github.com/aws/amazon-q-developer-cli/pull/2995)"
+        },
+        {
+          "type": "fixed",
+          "description": "Reloads only the built-in tools only for /experiment - [#3012](https://github.com/aws/amazon-q-developer-cli/pull/3012)"
+        },
+        {
+          "type": "added",
+          "description": "Add a `/reply` command - [#2680](https://github.com/aws/amazon-q-developer-cli/pull/2680)"
+        },
         {
           "type": "added",
           "description": "[Experimental] Adds checkpointing functionality using Git CLI commands - [#2896](https://github.com/aws/amazon-q-developer-cli/pull/2896)"


### PR DESCRIPTION
- Update version from 1.16.3 to 1.17.0 in Cargo.toml and Info.plist files
- Add new release entry for version 1.17.0 in feed.json with:
  - SSE support for MCP
  - /reply command
  - Experimental checkpointing functionality
  - Context usage percentage indicator
  - Custom prompts support
  - Various MCP fixes and improvements

🤖 Assisted by Amazon Q Developer

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
