### PR TITLE
fix: remove the update lock after a successful update with macOS

### DIFF
--- a/crates/q_cli/src/cli/internal/mod.rs
+++ b/crates/q_cli/src/cli/internal/mod.rs
@@ -62,6 +62,7 @@ use fig_proto::util::get_shell;
 use fig_util::directories::{
     figterm_socket_path,
     logs_dir,
+    update_lock_path,
 };
 use fig_util::env_var::QTERM_SESSION_ID;
 use fig_util::{
@@ -253,6 +254,8 @@ pub enum InternalSubcommand {
     DumpState {
         component: StateComponent,
     },
+    /// Currently only used by macOS after finishing an update. The old binary calls `FinishUpdate`
+    /// on the new binary at the end of updating.
     FinishUpdate {
         #[arg(long)]
         relaunch_dashboard: bool,
@@ -784,6 +787,8 @@ impl InternalSubcommand {
                     verbose: false,
                 })
                 .ok();
+
+                let _ = tokio::fs::remove_file(update_lock_path(&fig_os_shim::Context::new())?).await;
 
                 Ok(ExitCode::SUCCESS)
             },


### PR DESCRIPTION
*Description of changes:*
- Currently, when a user auto-updates into the latest version of `q`, we advertise updating into `kiro`. Since the update lockfile is not cleaned up on macOS after a successful update, this results in an error about "update in progress" until an hour has passed.
- Removing the lockfile after a successful update. Note that if we are updating the lockfile path between versions (q -> kiro), then the kiro finish update won't remove the q update lockfile. This is fine though, since the old lockfile won't be used anyways.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
